### PR TITLE
v0.1.3

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,8 +71,8 @@ do nothing. Do you feel like it could be more interesting?
 
 - [ ] Align the vibes of basil & campion to make it feel smoother
 
-- [ ] Basil
-  - [ ] Adjusted starting cost: 1 → 1.25
+- [x] Basil
+  - [x] Adjust starting cost: 1 → 1.25
   - [ ] Double starting cost but 2, 10 stepwise?
   - [x] More delay before flowering (maybe stg 24 flowers)
   - [x] Decrease max stage
@@ -87,7 +87,7 @@ do nothing. Do you feel like it could be more interesting?
   - [ ] Maximum statements
   - [ ] Death? Propagation?
   - [ ] Income per evolution instead of night
-  - [ ] Double growth cost
+  - [x] Double growth cost
   - [ ] Flower turns into fruit faster
   - [ ] Fruit falls off
   - [ ] Loading SLOW

--- a/TODO.md
+++ b/TODO.md
@@ -21,10 +21,13 @@
   - Hold on, collaborative and social interactions. Discord! Reddit!
 
 - [ ] Research notes
+  - Two players share progress with each other daily
   - Some players understand the profit puzzle for calendula, some don't
   - Players enjoy watching plants grow idly
   - Some players can't get pruning basil
   - Some players mistake max stage with max profit
+  - Many players are cautious about purchasing expensive items, which isn't the 
+  case usually for other theories
 
 - Let's think about it. A plant that takes 80 minutes to grow, and you have to
 do nothing. Do you feel like it could be more interesting?
@@ -55,6 +58,9 @@ do nothing. Do you feel like it could be more interesting?
 
 ## v0.2: Rabbits update
 
+- [ ] Notebook shows next cost
+- [ ] Tag various stuffs with readonly
+
 - [ ] Hopleek
   - Biting is on evolution queue instead of action?
   - [x] Leap years calculation
@@ -66,6 +72,7 @@ do nothing. Do you feel like it could be more interesting?
 - [ ] Align the vibes of basil & campion to make it feel smoother
 
 - [ ] Basil
+  - [ ] Double starting cost but 2, 10 stepwise?
   - [ ] More delay before flowering (maybe stg 24 flowers)
     - [ ] Delete the `I < S` rule
   - [ ] Decrease max stage
@@ -75,13 +82,19 @@ do nothing. Do you feel like it could be more interesting?
   their power immensely
   - [ ] Bees love flowers too?!!
   - [ ] https://gardenbenchtop.com/what-happens-when-basil-flowers/
-- [ ] Tag various stuffs with readonly
 
 - [x] Rose campion as first bush plant
+  - [ ] Maximum statements
   - [ ] Death? Propagation?
-    - [ ] How long does it live? When does it spread seeds?
-    - [ ] Cost increases when it spreads, so need to shovel old ones before new
-    - [ ] Propagation ratio: 0.5, rounded up
+  - [ ] Income per evolution instead of night
+  - [ ] Double growth cost
+  - [ ] Flower turns into fruit faster
+  - [ ] Fruit falls off
+  - [ ] Loading SLOW
+  - [ ] How long does it live? When does it spread seeds?
+  - [ ] Cost increases when it spreads, so need to shovel old ones before new
+  - [ ] Propagation ratio: 0.5, rounded up
+  - [ ] Add a parameter to adjust stagely income multiplier (1/4th is ok?)
   - [x] Passive income
   - [x] Nerf growth cost from 4 to 5? Stage 21 is so fast, how about 28?
   - [x] Extend rose campion seed period by a few stages

--- a/TODO.md
+++ b/TODO.md
@@ -86,7 +86,7 @@ do nothing. Do you feel like it could be more interesting?
 - [x] Rose campion as first bush plant
   - [ ] Maximum statements
   - [ ] Death? Propagation?
-  - [ ] Income per evolution instead of night
+  - [x] Income per evolution instead of night
   - [x] Double growth cost
   - [ ] Flower turns into fruit faster
   - [ ] Fruit falls off

--- a/TODO.md
+++ b/TODO.md
@@ -29,6 +29,11 @@ do nothing. Do you feel like it could be more interesting?
 
 ## Compost bin
 
+- [ ] Simple solitary flower
+  - Tulip?
+  - Buttercup
+  - No need, Cally is already easy to play
+
 - [ ] Colour schemes?
 - [ ] Timer function to measure growth
   - Device time measured by user is sufficient?
@@ -40,37 +45,14 @@ do nothing. Do you feel like it could be more interesting?
   - Only unlocks in a future update (classmates!)
   - Hard to implement since there's more to LG than when to harvest
 
-## v0.2: Rabbits update
-
-- [ ] Tag various stuffs with readonly
-
 - [ ] Different aspect ratios hav different graph bounds
 
-- [x] Preference table for decimal places
+- [ ] Newspapers
+- [ ] Add a Pruned commentary track
+  - 2 lazy
 
-- [x] Confirmation to harvest/prune
-  - Options menu
+## v0.2: Rabbits update
 
-- [ ] Basil
-  - [ ] More delay before flowering (maybe stg 24 flowers)
-  - [ ] Apex decreases synthesis when spawning leaves
-  - [ ] Side shoots grow more leaves but smaller
-  - [ ] Flower gives income? Can be made into tea - although should shrink
-  their power immensely
-  - [ ] Bees love flowers too?!!
-  - [ ] https://gardenbenchtop.com/what-happens-when-basil-flowers/
-
-- [x] updateAvailability() slow
-
-- [x] Rose campion as first bush plant
-  - [ ] Death? Propagation?
-  - [x] Passive income
-  - [x] Nerf growth cost from 4 to 5? Stage 21 is so fast, how about 28?
-  - [x] Extend rose campion seed period by a few stages
-
-- [ ] Simple solitary flower
-  - Tulip?
-  - Buttercup
 - [ ] Hopleek
   - Biting is on evolution queue instead of action?
   - [x] Leap years calculation
@@ -79,10 +61,33 @@ do nothing. Do you feel like it could be more interesting?
   - [ ] Repelled by rose campions and sunflowers
 - [ ] Sunflower
 
-- [ ] Newspapers
-- [ ] Add a Pruned commentary track
-  - 2 lazy
+- [ ] Align the vibes of basil & campion to make it feel smoother
 
+- [ ] Basil
+  - [ ] More delay before flowering (maybe stg 24 flowers)
+    - [ ] Delete the `I < S` rule
+  - [ ] Decrease max stage
+  - [ ] Apex decreases synthesis when spawning leaves
+  - [ ] Side shoots grow more leaves but smaller
+  - [ ] Flower gives income? Can be made into tea - although should shrink
+  their power immensely
+  - [ ] Bees love flowers too?!!
+  - [ ] https://gardenbenchtop.com/what-happens-when-basil-flowers/
+- [ ] Tag various stuffs with readonly
+
+- [x] Rose campion as first bush plant
+  - [ ] Death? Propagation?
+    - [ ] How long does it live? When does it spread seeds?
+    - [ ] Cost increases when it spreads, so need to shovel old ones before new
+    - [ ] Propagation ratio: 0.5, rounded up
+  - [x] Passive income
+  - [x] Nerf growth cost from 4 to 5? Stage 21 is so fast, how about 28?
+  - [x] Extend rose campion seed period by a few stages
+
+- [x] Preference table for decimal places
+- [x] Confirmation to harvest/prune
+  - Options menu
+- [x] updateAvailability() slow
 - [x] Bookshelf unlocks after tutorial to avoid confusion with unlock plot
 
 ## v0.1: Slumber Seeds

--- a/TODO.md
+++ b/TODO.md
@@ -72,13 +72,13 @@ do nothing. Do you feel like it could be more interesting?
 - [ ] Align the vibes of basil & campion to make it feel smoother
 
 - [ ] Basil
+  - [ ] Adjusted starting cost: 1 → 1.25
   - [ ] Double starting cost but 2, 10 stepwise?
-  - [ ] More delay before flowering (maybe stg 24 flowers)
-    - [ ] Delete the `I < S` rule
-  - [ ] Decrease max stage
-  - [ ] Apex decreases synthesis when spawning leaves
-  - [ ] Side shoots grow more leaves but smaller
-  - [ ] Flower gives income? Can be made into tea - although should shrink
+  - [x] More delay before flowering (maybe stg 24 flowers)
+  - [x] Decrease max stage
+  - [x] Apex decreases synthesis when spawning leaves
+  - [x] Side shoots grow more leaves but smaller
+  - [x] Flower gives income? Can be made into tea - although should shrink
   their power immensely
   - [ ] Bees love flowers too?!!
   - [ ] https://gardenbenchtop.com/what-happens-when-basil-flowers/

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,8 @@
 - [ ] Research notes
   - Some players understand the profit puzzle for calendula, some don't
   - Players enjoy watching plants grow idly
+  - Some players can't get pruning basil
+  - Some players mistake max stage with max profit
 
 - Let's think about it. A plant that takes 80 minutes to grow, and you have to
 do nothing. Do you feel like it could be more interesting?

--- a/TODO.md
+++ b/TODO.md
@@ -94,7 +94,7 @@ do nothing. Do you feel like it could be more interesting?
   - [ ] How long does it live? When does it spread seeds?
   - [ ] Cost increases when it spreads, so need to shovel old ones before new
   - [ ] Propagation ratio: 0.5, rounded up
-  - [ ] Add a parameter to adjust stagely income multiplier (1/4th is ok?)
+  - [ ] Add a parameter to adjust stagely income multiplier (1/2x for now?)
   - [x] Passive income
   - [x] Nerf growth cost from 4 to 5? Stage 21 is so fast, how about 28?
   - [x] Extend rose campion seed period by a few stages

--- a/design_doc.md
+++ b/design_doc.md
@@ -205,6 +205,8 @@ between tau not feeling bloated and pub multipliers not too small)
 - **Active sprouts? (Micro greens)**
   - You can eat sunflower sprouts, aaa
 - **Poison ivy**
+- **Gooseberry**, behaves like a goose and eats things
+  - Name origin is actually unrelated to geese
 - **Rhizomes?**
 - **Paleobotany** - time travelley stuff like cooksonia and zosterophyllum
 - **Fungi** - foraging?

--- a/design_doc.md
+++ b/design_doc.md
@@ -129,6 +129,13 @@ between tau not feeling bloated and pub multipliers not too small)
   - Name: Excursions? Lessons? ... Lemmas?
   - Beating them will unlock new plant types
   - Ideas: 5x+1 Cotton Conjecture, ~~Botched~~ Bloated Linden (lol)
+- **Floodplains**: plots that are to the right of river
+  - Hostile plants
+  - Multiple plants per plot
+  - Only either garden or this can be active at a time
+  - Labelled on 4ary values as `f_1`, `f_2`, ...
+- Etymologically and geologically, prairies are not possible
+- Rainforests are also too many trees for LG
 
 ## Plants
 
@@ -207,8 +214,10 @@ between tau not feeling bloated and pub multipliers not too small)
 - **Poison ivy**
 - **Gooseberry**, behaves like a goose and eats things
   - Name origin is actually unrelated to geese
+- **Hibiscus**
 - **Rhizomes?**
-- **Paleobotany** - time travelley stuff like cooksonia and zosterophyllum
+- **Bank vegetation near floodplains**: willow, ash (grows mistletoe)
+- **Silurian Paleobotany** - time travelley stuff: cooksonia, zosterophyllum
 - **Fungi** - foraging?
 - **Flower gender** mechanic?
 

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -4842,7 +4842,7 @@ let createColonyViewMenu = (colony: Colony) =>
     let tmpTitle = Localization.format(getLoc('colony'), colony.population,
     getLoc('plants')[colony.id].name, colony.stage);
     let tmpStage = colony.stage;
-    let cmtStage;
+    let cmtStage: number;
     let updateCommentary = () =>
     {
         let stages = getLoc('plants')[colony.id].stages;
@@ -4912,7 +4912,7 @@ let createColonyViewMenu = (colony: Colony) =>
                 tmpCmt = updateCommentary();
                 plantStats.text = Localization.format(getLoc('plantStats'),
                 cmtStage, tmpCmt, plantData[colony.id].maxStage ?? '∞',
-                plantData[colony.id].growthRate, colony.synthRate,
+                colony.synthRate, plantData[colony.id].growthRate,
                 plantData[colony.id].growthCost, colony.sequence.length);
                 tmpStage = colony.stage;
                 reconstructionTask =

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -74,7 +74,7 @@ const LOC_STRINGS =
         wip: 'Work in Progress',
 
         currencyTax: 'p (tax)',
-        pubTax: 'Tax on publish',
+        pubTax: 'Publish tax',
 
         btnView: 'View L-system',
         btnVar: 'Variables',
@@ -236,23 +236,23 @@ cuts off all A and K.\\\\—\\\\The Model specification section may be ignored.`
                 {
                     index:
                     [
-                        0, 4, 8, 9, 12, 13, 14, 17, 20,
-                        21, 22
+                        0, 4, 8, 10, 12, 14, 15, 18, 20,
+                        23, 24
                     ],
                     0: 'A seedling in its sweet slumber.',
                     4: 'The first pair of leaves pops up. A stem, as well.',
                     8: 'The second pair of leaves appears.',
-                    9: 'Little leaves start to grow over the first node.',
+                    10: 'Little leaves start to grow over the first node.',
                     12: 'The third pair of leaves appears.',
-                    13: 'Little leaves now grow over the second node.',
-                    14: 'This rhythm will repeat for a while.',
-                    17: `I'll show you what to do when it flowers, soon.`,
+                    14: 'Little leaves now grow over the second node.',
+                    15: 'This rhythm will repeat for a while.',
+                    18: `I'll show you what to do when it flowers, soon.`,
                     20: `It's about to flower. You can nip the stem now if you
 don't feel confident.`,
-                    21: `The first flower appears.`,
-                    22: `If the flower's still there, imagine it's sending a
-signal from top to bottom, all the way to basil base. Then, basil base will
-send another one back to the leaves.`,
+                    23: `The first flower will appear soon.`,
+                    24: `If the flower's there, imagine it's sending a signal
+from top to bottom, all the way to basil base. Then, basil base will send
+another one back to the leaves.`,
                 }
             },
             3:
@@ -389,7 +389,7 @@ Here's a recipe to make some delicious calendula bread:`
 `slightly intoxicating flavour.
 Even my dog loves it from time to time.
 
-Time to maturity: 6~7 weeks
+Time to maturity: 'I haven't timed it yet'
 
 If you intend to harvest, snip off the stem before it flowers. Otherwise, ` +
 `the plant will go into the end of its life cycle, and the leaves will lose ` +
@@ -3512,15 +3512,14 @@ const plantData: {[key: number]: Plant} =
     {
         system: new LSystem('BA(0.18, 0)',
         [
-            'A(r, t): r>=flowerThreshold = K(0)',
+            'A(r, t): r>=flowerThreshold = S(0)K(0.02, 8)',
             'A(r, t): t<3 = A(r+0.06, t+1)',
-            'A(r, t) = F(0.12, 1.44)[+L(0.06, min(r+0.06, maxLeafSize), 0)]/(180)[+L(0.06, min(r+0.06, maxLeafSize), 0)]/(90)I(0)A(r+0.06, 0)',
+            'A(r, t) = F(0.12, 1.44)[+[I(0)]T(0.2)L(0.06, min(r+0.12, maxLeafSize), 0)]/(180)[+L(0.06, min(r+0.12, maxLeafSize), 0)]/(90)A(r-0.06, 0)',
             'I(t) > S(type): type<=0 = S(type)I(t)',
-            'I(t): t<4 = I(t+1)',
-            'I(t) = F(0.12, 0.36)[+L(0.03, maxLeafSize/2, 0)]/(180)[+L(0.03, maxLeafSize/2, 0)]',
-            'K(t): t<=signalThreshold = S(0)/(90)[+K(1)][-K(1)]K(t+1)',
-            'K(t): t-2 = K(t+1)',
-            'K(t) = K(t+1)K(1)',
+            'I(t): t<5 = I(t+1)',
+            'I(t) = /(90)F(0.12, 0.72)T[+L(0.03, maxLeafSize/2, 0)]/(180)[+L(0.03, maxLeafSize/2, 0)]I(-6)',
+            'K(s, t): t>0 = K(s+0.02, 0)K(0.02, t-1)',
+            'K(s, t): s<1 = K(s+0.02, t)',
             'L(p, lim, s): s<1 && p<lim = L(p+0.03, lim, s)',
             'S(type) < L(p, lim, s): s<1 = L(p, p, 1)',
             'L(p, lim, s): s>=1 && p>0.06 = L(p-0.06, lim, s)',
@@ -3530,24 +3529,23 @@ const plantData: {[key: number]: Plant} =
             'B > S(type): type<=0 = BS(1)',
             'F(l, lim): l<lim = F(l+0.12, lim)',
             '~> #= Model specification',
-            '~> K(t) = /(90)F(min(1.25, sqrt(t/4)))T(-0.2){[k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//]}',
-            '~> k(size): size<1 = [++F(size/2).[-F(size/2).].]',
+            '~> K(t) = /(90)F(min(1.25, sqrt(t*2))){[k(min(0.75, t*4))//k(min(0.75, t*4))//k(min(0.75, t*4))//k(min(0.75, t*4))//k(min(0.75, t*4))//k(min(0.75, t*4))//]}',
+            '~> k(size): size<0.75 = [++F(size/2).[-F(size/2).].]',
             '~> k(size) = [++F(size/3).++[--F(size/2).][&F(size/2).].[^F(size/2).][--F(size/2).].[-F(size/2).].[F(size/2).].]',
-            '~> L(p, lim, s): s<1 = {\\(90)T(p*0.8)F(sqrt(p)).[-(48)F(p).+F(p).+&F(p).+F(p).][F(p)[&F(p)[F(p)[^F(p).].].].].[+(48)F(p).-F(p).-&F(p).-F(p).][F(p)[&F(p)[F(p)[^F(p).].].].]}',
-            '~> L(p, lim, s) = {\\(90)T(lim)F(sqrt(lim)).[--F(lim).+&F(lim).+&F(lim).+F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].].[++F(lim).-&F(lim).-&F(lim).-F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].]}',
-        ], 30, 0, 'BASIL', '+-&^/\\T', 1, {
-            'flowerThreshold': '1.38',
-            'maxLeafSize': '0.66',
-            'signalThreshold': '0'
+            '~> L(p, lim, s): s<1 = {[\\(90)T(p*0.9)F(sqrt(p)).[-(48)F(p).+F(p).+&F(p).+F(p).][F(p)[&F(p)[F(p)[^F(p).].].].].[+(48)F(p).-F(p).-&F(p).-F(p).][F(p)[&F(p)[F(p)[^F(p).].].].]]}',
+            '~> L(p, lim, s) = {[\\(90)T(lim*1.2)F(sqrt(lim)).[--F(lim).+&F(lim).+&F(lim).+F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].].[++F(lim).-&F(lim).-&F(lim).-F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].]]}',
+        ], 30, 0, 'BASIL', '+-&^/\\T', -0.16, {
+            'flowerThreshold': '0.96',
+            'maxLeafSize': '0.66'
         }),
-        maxStage: 54,
-        cost: new ExponentialCost(1, 1),
+        maxStage: 46,
+        cost: new ExponentialCost(1.25, 1),
         growthRate: BigNumber.FOUR,
-        growthCost: BigNumber.THREE,
+        growthCost: BigNumber.from(2.5),
         actions:
         [
             {   // Always a harvest
-                symbols: new Set('L'),
+                symbols: new Set('KL'),
                 // system: new LSystem('', ['L=']),
                 killColony: true
             },
@@ -3562,7 +3560,7 @@ const plantData: {[key: number]: Plant} =
             'B': null,
             'F': [2, 2],
             'I': [0],
-            'K': [0],
+            'K': [2, 0],
             'L': [2, 2, 0],
             'S': [0],
             '/': [0]
@@ -3584,7 +3582,7 @@ const plantData: {[key: number]: Plant} =
             };
         }
     },
-    3:   // Rose campion
+    3:  // Rose campion
     {
         system: new LSystem('/(45)&(5)A(0.1, 3)', [
             'A(r, t): t>0 = A(r+0.05, t-1)',
@@ -3699,16 +3697,16 @@ const plantData: {[key: number]: Plant} =
             };
         }
     },
-    9002:  // BRasil (test)
+    9002:   // BRasil (test)
     {
         system: new LSystem('BA(0.18, 0)',
         [
             'A(r, t): r>=flowerThreshold = S(0)K(0.02, 8)',
             'A(r, t): t<3 = A(r+0.06, t+1)',
-            'A(r, t) = F(0.12, 1.44)[+[I(0)]T(0.2)L(0.06, min(r+0.12, maxLeafSize), 0)]/(180)[+L(0.06, min(r+0.12, maxLeafSize), 0)]/(90)A(r-0.12, 0)',
+            'A(r, t) = F(0.12, 1.44)[+[I(0)]T(0.2)L(0.06, min(r+0.12, maxLeafSize), 0)]/(180)[+L(0.06, min(r+0.12, maxLeafSize), 0)]/(90)A(r-0.06, 0)',
             'I(t) > S(type): type<=0 = S(type)I(t)',
-            'I(t): t<7 = I(t+1)',
-            'I(t) = /(90)F(0.12, 0.72)T[+L(0.03, maxLeafSize/2, 0)]/(180)[+L(0.03, maxLeafSize/2, 0)]I(-8)',
+            'I(t): t<5 = I(t+1)',
+            'I(t) = /(90)F(0.12, 0.72)T[+L(0.03, maxLeafSize/2, 0)]/(180)[+L(0.03, maxLeafSize/2, 0)]I(-6)',
             'K(s, t): t>0 = K(s+0.02, 0)K(0.02, t-1)',
             'K(s, t): s<1 = K(s+0.02, t)',
             'L(p, lim, s): s<1 && p<lim = L(p+0.03, lim, s)',
@@ -3725,12 +3723,12 @@ const plantData: {[key: number]: Plant} =
             '~> k(size) = [++F(size/3).++[--F(size/2).][&F(size/2).].[^F(size/2).][--F(size/2).].[-F(size/2).].[F(size/2).].]',
             '~> L(p, lim, s): s<1 = {[\\(90)T(p*0.9)F(sqrt(p)).[-(48)F(p).+F(p).+&F(p).+F(p).][F(p)[&F(p)[F(p)[^F(p).].].].].[+(48)F(p).-F(p).-&F(p).-F(p).][F(p)[&F(p)[F(p)[^F(p).].].].]]}',
             '~> L(p, lim, s) = {[\\(90)T(lim*1.2)F(sqrt(lim)).[--F(lim).+&F(lim).+&F(lim).+F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].].[++F(lim).-&F(lim).-&F(lim).-F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].]]}',
-        ], 30, 0, 'BASIL', '+-&^/\\T', -0.2, {
-            'flowerThreshold': '0.66',
+        ], 30, 0, 'BASIL', '+-&^/\\T', -0.16, {
+            'flowerThreshold': '0.96',
             'maxLeafSize': '0.66'
         }),
-        maxStage: 50,
-        cost: new ExponentialCost(1, 1),
+        maxStage: 46,
+        cost: new ExponentialCost(1.25, 1),
         growthRate: BigNumber.FOUR,
         growthCost: BigNumber.from(2.5),
         actions:
@@ -3751,7 +3749,7 @@ const plantData: {[key: number]: Plant} =
             'B': null,
             'F': [2, 2],
             'I': [0],
-            'K': [0],
+            'K': [2, 0],
             'L': [2, 2, 0],
             'S': [0],
             '/': [0]
@@ -3773,6 +3771,16 @@ const plantData: {[key: number]: Plant} =
             };
         }
     },
+}
+// For reference only
+const plantIDLookup =
+{
+    calendula: 1,
+    basil: 2,
+    campion: 3,
+    rose: 3,
+    arrow: 9001,
+    brasil: 9002
 }
 
 let haxEnabled = false;
@@ -4456,8 +4464,7 @@ var getSecondaryEquation = () =>
         T_{\\text{p}}=${taxRate}\\times\\max\\text{p}\\\\\\\\`;
         let tauInfo = `${theory.latexSymbol}=\\max\\text{p}^
         ${tauRate.toString(0)}`;
-        return `\\begin{array}{c}${theory.publicationUpgrade.level &&
-        theory.canPublish ? taxInfo : ''}${tauInfo}\\end{array}`;
+        return `\\begin{array}{c}${taxInfo}${tauInfo}\\end{array}`;
     }
 
     switch(colonyMode)

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -229,9 +229,9 @@ known as the golden angle.`,
                 name: 'Basil',
                 info: 'A fast growing herb that requires a bit of care.',
                 LsDetails: `A: apex (stem shoot)\\\\B: base\\\\F: internode\\\\
-I : shortened stem\\\\K: flower\\\\L: leaf\\\\—\\\\Harvest returns profit as the
-sum of all L.\\\\Prune cuts off all A and K.\\\\—\\\\The Model specification
-section may be ignored.`,
+I : shortened stem\\\\K: flower\\\\L: leaf\\\\S: signal (type 0 travels down,
+type 1 travels up)\\\\—\\\\Harvest returns profit as the sum of all L.\\\\Prune
+cuts off all A and K.\\\\—\\\\The Model specification section may be ignored.`,
                 stages:
                 {
                     index:
@@ -638,6 +638,11 @@ let getSmallBtnSize = (width: number): number =>
         return 40;
 
     return 32;
+}
+
+let getProgBarSize = (width: number): number =>
+{
+    return getSmallBtnSize(width) / 2;
 }
 
 /**
@@ -3540,6 +3545,7 @@ const plantData: {[key: number]: Plant} =
             'I': [0],
             'K': [0],
             'L': [2, 2, 0],
+            'S': [0],
             '/': [0]
         },
         camera: (stage) =>
@@ -5004,7 +5010,7 @@ let createBookMenu = (book: Book) =>
     ({
         text: pages[page].title,
         margin: new Thickness(0, 4),
-        heightRequest: 20,
+        heightRequest: getProgBarSize(ui.screenWidth),
         horizontalTextAlignment: TextAlignment.CENTER,
         verticalTextAlignment: TextAlignment.CENTER
     });

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -5791,7 +5791,7 @@ let createWorldMenu = () =>
             {
                 Sound.playClick();
                 actionConfirm = !actionConfirm;
-                APSwitch.isToggled = actionConfirm;
+                ACSwitch.isToggled = actionConfirm;
             }
         }
     });
@@ -6071,6 +6071,7 @@ var setInternalState = (stateStr: string) =>
         colonyMode = state.settings.colonyMode;
         fancyPlotTitle = state.settings.fancyPlotTitle;
         actionPanelOnTop = state.settings.actionPanelOnTop;
+        actionConfirm = state.settings.actionConfirm;
     }
 
     if('colonyViewConfig' in state)

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -63,7 +63,7 @@ const LS_CONTEXT =
 const BACKTRACK_LIST = new Set('+-&^\\/|[$T');
 // Leaves and apices
 const SYNTHABLE_SYMBOLS = new Set('AL');
-const MAX_CHARS_PER_TICK = 150;
+const MAX_CHARS_PER_TICK = 500;
 const NORMALISE_QUATERNIONS = false;
 const MENU_LANG = Localization.language;
 const LOC_STRINGS =
@@ -4380,10 +4380,21 @@ var tick = (elapsedTime: number, multiplier: number) =>
         growthCoord = (timeCos + 1) / 2;
         // floatingWipLabel.rotateTo(-3 - Math.cos(time * Math.PI / 6) * 12,
         // 180, Easing.LINEAR);
+        managerLoadingInd.isRunning = manager.busy;
     }
     theory.invalidateSecondaryEquation();
     // theory.invalidateTertiaryEquation();
 }
+
+let managerLoadingInd = ui.createActivityIndicator
+({
+    margin: new Thickness(4),
+    horizontalOptions: LayoutOptions.END,
+    verticalOptions: LayoutOptions.END,
+    heightRequest: getImageSize(ui.screenWidth),
+    widthRequest: getImageSize(ui.screenWidth),
+    isRunning: manager.busy
+});
 
 var getEquationOverlay = () =>
 {
@@ -4396,6 +4407,7 @@ var getEquationOverlay = () =>
         children:
         [
             // floatingWipLabel,
+            managerLoadingInd,
             ui.createLatexLabel
             ({
                 row: 0, column: 0,
@@ -4960,6 +4972,9 @@ let createColonyViewMenu = (colony: Colony) =>
     });
     let updateReconstruction = () =>
     {
+        if(manager.busy)
+            return reconstructionTask.result;
+
         if(!('result' in reconstructionTask) ||
         ('result' in reconstructionTask && reconstructionTask.start))
         {
@@ -5940,28 +5955,33 @@ let unBigStringify = (_, val) =>
     return val;
 }
 
-var getInternalState = () => JSON.stringify
-({
-    version: version,
-    haxEnabled: haxEnabled,
-    time: time,
-    plotIdx: plotIdx,
-    colonyIdx: colonyIdx,
-    plantIdx: plantIdx,
-    finishedTutorial: finishedTutorial,
-    manager: manager.object,
-    settings:
-    {
-        graphMode2D: graphMode2D,
-        graphMode3D: graphMode3D,
-        colonyMode: colonyMode,
-        fancyPlotTitle: fancyPlotTitle,
-        actionPanelOnTop: actionPanelOnTop,
-        actionConfirm: actionConfirm
-    },
-    colonyViewConfig: colonyViewConfig,
-    notebook: notebook
-}, bigStringify);
+var getInternalState = () =>
+{
+    // if(manager.busy)
+    //     return '';
+    return JSON.stringify
+    ({
+        version: version,
+        haxEnabled: haxEnabled,
+        time: time,
+        plotIdx: plotIdx,
+        colonyIdx: colonyIdx,
+        plantIdx: plantIdx,
+        finishedTutorial: finishedTutorial,
+        manager: manager.object,
+        settings:
+        {
+            graphMode2D: graphMode2D,
+            graphMode3D: graphMode3D,
+            colonyMode: colonyMode,
+            fancyPlotTitle: fancyPlotTitle,
+            actionPanelOnTop: actionPanelOnTop,
+            actionConfirm: actionConfirm
+        },
+        colonyViewConfig: colonyViewConfig,
+        notebook: notebook
+    }, bigStringify);
+}
 
 var setInternalState = (stateStr: string) =>
 {

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -169,6 +169,7 @@ Profit\\colon\\enspace {8}p\\\\{9}`,
         [
             'Colony view: Off',
             'Colony view: Single',
+            'Colony view: Single 2',
             'Colony view: List'
         ],
         actionPanelLocations:
@@ -4378,8 +4379,15 @@ var getSecondaryEquation = () =>
             // @ts-expect-error
             plantData[c.id].growthRate * BigNumber.from(growthCoord), c.profit,
             status)}}`;
-            // return `\\text{${Localization.format(getLoc('colony'), c.population, getLoc('plants')[c.id].name, c.stage)}}\\\\E=${c.energy},\\enspace g=${c.growth}/${plantData[c.id].growthCost * BigNumber.from(c.sequence.length)}\\\\P=${c.synthRate}/\\text{s},\\enspace\\pi =${c.profit}\\text{p}\\\\(${colonyIdx[plotIdx] + 1}/${manager.colonies[plotIdx].length})\\\\`;
         case 2:
+            return `\\text{${Localization.format(getLoc('colony'), c.population,
+            getLoc('plants')[c.id].name, c.stage)}}\\\\E=${c.energy},\\enspace
+            g=${c.growth}/${// @ts-expect-error
+            plantData[c.id].growthCost * BigNumber.from(c.sequence.length)}
+            \\\\P=${c.synthRate}/\\text{s},\\enspace\\pi =${c.profit}\\text{p}
+            \\\\(${colonyIdx[plotIdx] + 1}/${manager.colonies[plotIdx].length})
+            \\\\`;
+        case 3:
             let result = '';
             for(let i = 0; i < colonyIdx[plotIdx]; ++i)
             {
@@ -5539,7 +5547,7 @@ let createWorldMenu = () =>
     ({
         row: 3, column: 1,
         minimum: 0,
-        maximum: 2,
+        maximum: 3,
         value: colonyMode,
         onValueChanged: () =>
         {

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -91,7 +91,7 @@ const LOC_STRINGS =
 
         menuConfirm: 'Confirmation',
         actionConfirmDialogue: `You are about to perform a {0} on\\\\
-plot {1}, colony {2}.\\\\\n\n\\\\Do you want to continue?`,
+{3} (plot {1}-{2}).\\\\\n\n\\\\Do you want to continue?`,
 
         labelSave: 'Last save: {0}s',
         labelActions: ['Harvest', 'Prune'],
@@ -263,7 +263,7 @@ another one back to the leaves.`,
                 info: 'A great sight for your garden. Provides daily income.',
                 LsDetails: `A: apex (stem shoot)\\\\F: internode\\\\K: flower
 \\\\L: leaf\\\\O: fruit\\\\—\\\\Harvest returns profit as the sum of all K.\\\\
-Passively provides income per day equal to total profit.\\\\—\\\\The Model
+Passively provides income per stage equal to total profit.\\\\—\\\\The Model
 specification section may be ignored.`,
                 stages:
                 {
@@ -409,8 +409,8 @@ Rose campion is also used as a sedative, or for wound treatments, or wicks ` +
 
 Time to maturity: 'I haven't timed it yet'
 
-Every midnight, pollinators will pay you a penny or two after a hearty meal ` +
-`during the day.`
+Every time it grows, pollinators will pay you a few pennies for having ` +
+`provided them much hearty meals.`
             }
         },
 
@@ -3288,6 +3288,10 @@ class ColonyManager
         c.sequence = this.deriveTask.derivation;
         c.params = this.deriveTask.parameters;
         c.synthRate = this.calcTask.synthRate;
+        
+        if(plantData[c.id].stagelyIncome)
+            this.reap(c, plantData[c.id].stagelyIncome);
+
         c.profit = this.calcTask.profit;
 
         ++c.stage;
@@ -3413,6 +3417,7 @@ interface Plant
     growthRate: BigNumber;
     growthCost: BigNumber;
     dailyIncome?: boolean;
+    stagelyIncome?: BigNumber;
     actions: Action[];
     decimals: {[key: string]: number[]};
     camera: (stage: number) => RendererCamera;
@@ -3632,11 +3637,11 @@ const plantData: {[key: number]: Plant} =
         ], 31, 0, 'A', '', -0.6, {
             'maxLeafSize': '0.625'
         }),
-        maxStage: 30,
+        maxStage: 28,
         cost: new ExponentialCost(10000, Math.log2(5)),
         growthRate: BigNumber.FIVE,
         growthCost: BigNumber.FIVE,//BigNumber.from(2.5),
-        dailyIncome: true,
+        stagelyIncome: BigNumber.ONE,
         actions:
         [
             {
@@ -5572,6 +5577,7 @@ let createShelfMenu = () =>
 
 let createConfirmationMenu = (plot: number, index: number, id: number) =>
 {
+    let c = manager.colonies[plot][index];
     let menu = ui.createPopup
     ({
         // isPeekable: true,
@@ -5583,7 +5589,9 @@ let createConfirmationMenu = (plot: number, index: number, id: number) =>
                 ui.createLatexLabel
                 ({
                     text: Localization.format(getLoc('actionConfirmDialogue'),
-                    getLoc('labelActions')[id], plot + 1, index + 1),
+                    getLoc('labelActions')[id], plot + 1, index + 1,
+                    Localization.format(getLoc('colony'), c.population,
+                    getLoc('plants')[c.id].name, c.stage)),
                     horizontalTextAlignment: TextAlignment.CENTER,
                     margin: new Thickness(0, 15)
                 }),

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -52,7 +52,7 @@ Welcome to Lemma's Garden, an idle botanical theory built on the grammar of ` +
     return descs[language] ?? descs.en;
 }
 var authors = 'propfeds\n\nThanks to:\ngame-icons.net, for the icons';
-var version = 0.102;
+var version = 0.103;
 
 const MAX_INT = 0x7fffffff;
 const TRIM_SP = /\s+/g;
@@ -70,7 +70,7 @@ const LOC_STRINGS =
 {
     en:
     {
-        versionName: `Version: 0.1.2h1, Slumber Seeds`,
+        versionName: `Version: 0.1.3, Slumber Seeds`,
         wip: 'Work in Progress',
 
         currencyTax: 'p (tax)',

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -93,6 +93,7 @@ const LOC_STRINGS =
         actionConfirmDialogue: `You are about to perform a {0} on\\\\
 plot {1}, colony {2}.\\\\\n\n\\\\Do you want to continue?`,
 
+        labelSave: 'Last save: {0}s',
         labelActions: ['Harvest', 'Prune'],
         labelSettings: 'Settings',
         labelFilter: 'Filter: ',
@@ -190,8 +191,8 @@ Profit\\colon\\enspace {8}p\\\\{9}`,
                 name: 'Calendula',
                 info: 'A classic flower to start the month.',
                 LsDetails: `A: apex (stem shoot)\\\\F: internode\\\\I : flower
-stem\\\\K: flower\\\\L: leaf\\\\—\\\\Harvest returns profit as the sum of all K.
-\\\\—\\\\The Model specification section may be ignored.`,
+stem\\\\K: flower\\\\L: leaf\\\\—\\\\Harvest returns profit as the sum of all K
+(first parameter).\\\\—\\\\The Model specification section may be ignored.`,
                 stages:
                 {
                     index:
@@ -230,8 +231,9 @@ known as the golden angle.`,
                 info: 'A fast growing herb that requires a bit of care.',
                 LsDetails: `A: apex (stem shoot)\\\\B: base\\\\F: internode\\\\
 I : shortened stem\\\\K: flower\\\\L: leaf\\\\S: signal (type 0 travels down,
-type 1 travels up)\\\\—\\\\Harvest returns profit as the sum of all L.\\\\Prune
-cuts off all A and K.\\\\—\\\\The Model specification section may be ignored.`,
+type 1 travels up)\\\\—\\\\Harvest returns profit as the sum of all L and K.\\\\
+Prune cuts off all A and K.\\\\—\\\\The Model specification section may be
+ignored.`,
                 stages:
                 {
                     index:
@@ -3810,6 +3812,7 @@ const plantIDLookup =
 
 let haxEnabled = false;
 let time = 0;
+let lastSave = 0;
 let days = 0;
 let years = 0;
 let insolationCoord = 0;
@@ -4007,7 +4010,14 @@ const settingsLabel = ui.createLatexLabel
     row: 0, column: 1,
     verticalTextAlignment: TextAlignment.START,
     margin: new Thickness(0, 9),
-    text: getLoc('labelSettings'),
+    text: () =>
+    {
+        let multiplier = game.isRewardActive ? 1.5 : 1;
+        let dt = (time - lastSave) / multiplier;
+        if(dt < 30)
+            return getLoc('labelSettings');
+        return Localization.format(getLoc('labelSave'), dt.toFixed(1));
+    },
     fontSize: 10,
     textColor: Color.TEXT_MEDIUM
 });
@@ -5957,8 +5967,10 @@ let unBigStringify = (_, val) =>
 
 var getInternalState = () =>
 {
-    // if(manager.busy)
-    //     return '';
+    if(manager.busy)
+        return '';
+
+    lastSave = time;
     return JSON.stringify
     ({
         version: version,
@@ -6012,6 +6024,8 @@ var setInternalState = (stateStr: string) =>
         (Math.cos(phase * 2 * Math.PI) - 1) / Math.PI;
         growthIntegral = time / 2 + 36 * Math.sin(time * Math.PI / 72) /
         Math.PI;
+
+        lastSave = state.time;
     }
 
     if('plotIdx' in state)

--- a/theory.js
+++ b/theory.js
@@ -70,7 +70,7 @@ const LOC_STRINGS = {
         btnNo: 'No',
         menuConfirm: 'Confirmation',
         actionConfirmDialogue: `You are about to perform a {0} on\\\\
-plot {1}, colony {2}.\\\\\n\n\\\\Do you want to continue?`,
+{3} (plot {1}-{2}).\\\\\n\n\\\\Do you want to continue?`,
         labelSave: 'Last save: {0}s',
         labelActions: ['Harvest', 'Prune'],
         labelSettings: 'Settings',
@@ -221,7 +221,7 @@ another one back to the leaves.`,
                 info: 'A great sight for your garden. Provides daily income.',
                 LsDetails: `A: apex (stem shoot)\\\\F: internode\\\\K: flower
 \\\\L: leaf\\\\O: fruit\\\\—\\\\Harvest returns profit as the sum of all K.\\\\
-Passively provides income per day equal to total profit.\\\\—\\\\The Model
+Passively provides income per stage equal to total profit.\\\\—\\\\The Model
 specification section may be ignored.`,
                 stages: {
                     index: [
@@ -348,8 +348,8 @@ Rose campion is also used as a sedative, or for wound treatments, or wicks ` +
 
 Time to maturity: 'I haven't timed it yet'
 
-Every midnight, pollinators will pay you a penny or two after a hearty meal ` +
-                    `during the day.`
+Every time it grows, pollinators will pay you a few pennies for having ` +
+                    `provided them much hearty meals.`
             }
         },
         manualTitle: 'Lindenmayer Systems',
@@ -2506,6 +2506,8 @@ class ColonyManager {
         c.sequence = this.deriveTask.derivation;
         c.params = this.deriveTask.parameters;
         c.synthRate = this.calcTask.synthRate;
+        if (plantData[c.id].stagelyIncome)
+            this.reap(c, plantData[c.id].stagelyIncome);
         c.profit = this.calcTask.profit;
         ++c.stage;
         this.ancestreeTask =
@@ -2775,11 +2777,11 @@ const plantData = {
         ], 31, 0, 'A', '', -0.6, {
             'maxLeafSize': '0.625'
         }),
-        maxStage: 30,
+        maxStage: 28,
         cost: new ExponentialCost(10000, Math.log2(5)),
         growthRate: BigNumber.FIVE,
         growthCost: BigNumber.FIVE,
-        dailyIncome: true,
+        stagelyIncome: BigNumber.ONE,
         actions: [
             {
                 symbols: new Set('K'),
@@ -4357,13 +4359,14 @@ let createShelfMenu = () => {
     return menu;
 };
 let createConfirmationMenu = (plot, index, id) => {
+    let c = manager.colonies[plot][index];
     let menu = ui.createPopup({
         // isPeekable: true,
         title: getLoc('menuConfirm'),
         content: ui.createStackLayout({
             children: [
                 ui.createLatexLabel({
-                    text: Localization.format(getLoc('actionConfirmDialogue'), getLoc('labelActions')[id], plot + 1, index + 1),
+                    text: Localization.format(getLoc('actionConfirmDialogue'), getLoc('labelActions')[id], plot + 1, index + 1, Localization.format(getLoc('colony'), c.population, getLoc('plants')[c.id].name, c.stage)),
                     horizontalTextAlignment: TextAlignment.CENTER,
                     margin: new Thickness(0, 15)
                 }),

--- a/theory.js
+++ b/theory.js
@@ -38,7 +38,7 @@ Welcome to Lemma's Garden, an idle botanical theory built on the grammar of ` +
     return descs[language] ?? descs.en;
 };
 var authors = 'propfeds\n\nThanks to:\ngame-icons.net, for the icons';
-var version = 0.102;
+var version = 0.103;
 const MAX_INT = 0x7fffffff;
 const TRIM_SP = /\s+/g;
 const LS_RULE = /([^:]+)(:(.+))?=(.*)/;
@@ -52,7 +52,7 @@ const NORMALISE_QUATERNIONS = false;
 const MENU_LANG = Localization.language;
 const LOC_STRINGS = {
     en: {
-        versionName: `Version: 0.1.2h1, Slumber Seeds`,
+        versionName: `Version: 0.1.3, Slumber Seeds`,
         wip: 'Work in Progress',
         currencyTax: 'p (tax)',
         pubTax: 'Tax on publish\\colon',

--- a/theory.js
+++ b/theory.js
@@ -47,7 +47,7 @@ const LS_CONTEXT = /((.)(\(([^\)]+)\))?<)?((.)(\(([^\)]+)\))?)(>(.)(\(([^\)]+)\)
 const BACKTRACK_LIST = new Set('+-&^\\/|[$T');
 // Leaves and apices
 const SYNTHABLE_SYMBOLS = new Set('AL');
-const MAX_CHARS_PER_TICK = 150;
+const MAX_CHARS_PER_TICK = 500;
 const NORMALISE_QUATERNIONS = false;
 const MENU_LANG = Localization.language;
 const LOC_STRINGS = {
@@ -3408,10 +3408,19 @@ var tick = (elapsedTime, multiplier) => {
         growthCoord = (timeCos + 1) / 2;
         // floatingWipLabel.rotateTo(-3 - Math.cos(time * Math.PI / 6) * 12,
         // 180, Easing.LINEAR);
+        managerLoadingInd.isRunning = manager.busy;
     }
     theory.invalidateSecondaryEquation();
     // theory.invalidateTertiaryEquation();
 };
+let managerLoadingInd = ui.createActivityIndicator({
+    margin: new Thickness(4),
+    horizontalOptions: LayoutOptions.END,
+    verticalOptions: LayoutOptions.END,
+    heightRequest: getImageSize(ui.screenWidth),
+    widthRequest: getImageSize(ui.screenWidth),
+    isRunning: manager.busy
+});
 var getEquationOverlay = () => {
     let result = ui.createGrid({
         // rowDefinitions: ['1*', '1*'],
@@ -3420,6 +3429,7 @@ var getEquationOverlay = () => {
         cascadeInputTransparent: false,
         children: [
             // floatingWipLabel,
+            managerLoadingInd,
             ui.createLatexLabel({
                 row: 0, column: 0,
                 horizontalTextAlignment: TextAlignment.CENTER,
@@ -3875,6 +3885,8 @@ let createColonyViewMenu = (colony) => {
         }
     });
     let updateReconstruction = () => {
+        if (manager.busy)
+            return reconstructionTask.result;
         if (!('result' in reconstructionTask) ||
             ('result' in reconstructionTask && reconstructionTask.start)) {
             reconstructionTask = plantData[colony.id].system.reconstruct(colony, colonyViewConfig[colony.id].filter, colonyViewConfig[colony.id].params, reconstructionTask);
@@ -4647,26 +4659,30 @@ let unBigStringify = (_, val) => {
     }
     return val;
 };
-var getInternalState = () => JSON.stringify({
-    version: version,
-    haxEnabled: haxEnabled,
-    time: time,
-    plotIdx: plotIdx,
-    colonyIdx: colonyIdx,
-    plantIdx: plantIdx,
-    finishedTutorial: finishedTutorial,
-    manager: manager.object,
-    settings: {
-        graphMode2D: graphMode2D,
-        graphMode3D: graphMode3D,
-        colonyMode: colonyMode,
-        fancyPlotTitle: fancyPlotTitle,
-        actionPanelOnTop: actionPanelOnTop,
-        actionConfirm: actionConfirm
-    },
-    colonyViewConfig: colonyViewConfig,
-    notebook: notebook
-}, bigStringify);
+var getInternalState = () => {
+    // if(manager.busy)
+    //     return '';
+    return JSON.stringify({
+        version: version,
+        haxEnabled: haxEnabled,
+        time: time,
+        plotIdx: plotIdx,
+        colonyIdx: colonyIdx,
+        plantIdx: plantIdx,
+        finishedTutorial: finishedTutorial,
+        manager: manager.object,
+        settings: {
+            graphMode2D: graphMode2D,
+            graphMode3D: graphMode3D,
+            colonyMode: colonyMode,
+            fancyPlotTitle: fancyPlotTitle,
+            actionPanelOnTop: actionPanelOnTop,
+            actionConfirm: actionConfirm
+        },
+        colonyViewConfig: colonyViewConfig,
+        notebook: notebook
+    }, bigStringify);
+};
 var setInternalState = (stateStr) => {
     if (!stateStr)
         return;

--- a/theory.js
+++ b/theory.js
@@ -140,6 +140,7 @@ Profit\\colon\\enspace {8}p\\\\{9}`,
         colonyModes: [
             'Colony view: Off',
             'Colony view: Single',
+            'Colony view: Single 2',
             'Colony view: List'
         ],
         actionPanelLocations: [
@@ -3368,8 +3369,14 @@ var getSecondaryEquation = () => {
             plantData[c.id].growthCost * BigNumber.from(c.sequence.length), 
             // @ts-expect-error
             plantData[c.id].growthRate * BigNumber.from(growthCoord), c.profit, status)}}`;
-        // return `\\text{${Localization.format(getLoc('colony'), c.population, getLoc('plants')[c.id].name, c.stage)}}\\\\E=${c.energy},\\enspace g=${c.growth}/${plantData[c.id].growthCost * BigNumber.from(c.sequence.length)}\\\\P=${c.synthRate}/\\text{s},\\enspace\\pi =${c.profit}\\text{p}\\\\(${colonyIdx[plotIdx] + 1}/${manager.colonies[plotIdx].length})\\\\`;
         case 2:
+            return `\\text{${Localization.format(getLoc('colony'), c.population, getLoc('plants')[c.id].name, c.stage)}}\\\\E=${c.energy},\\enspace
+            g=${c.growth}/${ // @ts-expect-error
+            plantData[c.id].growthCost * BigNumber.from(c.sequence.length)}
+            \\\\P=${c.synthRate}/\\text{s},\\enspace\\pi =${c.profit}\\text{p}
+            \\\\(${colonyIdx[plotIdx] + 1}/${manager.colonies[plotIdx].length})
+            \\\\`;
+        case 3:
             let result = '';
             for (let i = 0; i < colonyIdx[plotIdx]; ++i) {
                 let d = manager.colonies[plotIdx][i];
@@ -4291,7 +4298,7 @@ let createWorldMenu = () => {
     let CMSlider = ui.createSlider({
         row: 3, column: 1,
         minimum: 0,
-        maximum: 2,
+        maximum: 3,
         value: colonyMode,
         onValueChanged: () => {
             colonyMode = Math.round(CMSlider.value);

--- a/theory.js
+++ b/theory.js
@@ -71,6 +71,7 @@ const LOC_STRINGS = {
         menuConfirm: 'Confirmation',
         actionConfirmDialogue: `You are about to perform a {0} on\\\\
 plot {1}, colony {2}.\\\\\n\n\\\\Do you want to continue?`,
+        labelSave: 'Last save: {0}s',
         labelActions: ['Harvest', 'Prune'],
         labelSettings: 'Settings',
         labelFilter: 'Filter: ',
@@ -154,8 +155,8 @@ Profit\\colon\\enspace {8}p\\\\{9}`,
                 name: 'Calendula',
                 info: 'A classic flower to start the month.',
                 LsDetails: `A: apex (stem shoot)\\\\F: internode\\\\I : flower
-stem\\\\K: flower\\\\L: leaf\\\\—\\\\Harvest returns profit as the sum of all K.
-\\\\—\\\\The Model specification section may be ignored.`,
+stem\\\\K: flower\\\\L: leaf\\\\—\\\\Harvest returns profit as the sum of all K
+(first parameter).\\\\—\\\\The Model specification section may be ignored.`,
                 stages: {
                     index: [
                         0,
@@ -191,8 +192,9 @@ known as the golden angle.`,
                 info: 'A fast growing herb that requires a bit of care.',
                 LsDetails: `A: apex (stem shoot)\\\\B: base\\\\F: internode\\\\
 I : shortened stem\\\\K: flower\\\\L: leaf\\\\S: signal (type 0 travels down,
-type 1 travels up)\\\\—\\\\Harvest returns profit as the sum of all L.\\\\Prune
-cuts off all A and K.\\\\—\\\\The Model specification section may be ignored.`,
+type 1 travels up)\\\\—\\\\Harvest returns profit as the sum of all L and K.\\\\
+Prune cuts off all A and K.\\\\—\\\\The Model specification section may be
+ignored.`,
                 stages: {
                     index: [
                         0, 4, 8, 10, 12, 14, 15, 18, 20,
@@ -2938,6 +2940,7 @@ const plantIDLookup = {
 };
 let haxEnabled = false;
 let time = 0;
+let lastSave = 0;
 let days = 0;
 let years = 0;
 let insolationCoord = 0;
@@ -3104,7 +3107,13 @@ const settingsLabel = ui.createLatexLabel({
     row: 0, column: 1,
     verticalTextAlignment: TextAlignment.START,
     margin: new Thickness(0, 9),
-    text: getLoc('labelSettings'),
+    text: () => {
+        let multiplier = game.isRewardActive ? 1.5 : 1;
+        let dt = (time - lastSave) / multiplier;
+        if (dt < 30)
+            return getLoc('labelSettings');
+        return Localization.format(getLoc('labelSave'), dt.toFixed(1));
+    },
     fontSize: 10,
     textColor: Color.TEXT_MEDIUM
 });
@@ -4660,8 +4669,9 @@ let unBigStringify = (_, val) => {
     return val;
 };
 var getInternalState = () => {
-    // if(manager.busy)
-    //     return '';
+    if (manager.busy)
+        return '';
+    lastSave = time;
     return JSON.stringify({
         version: version,
         haxEnabled: haxEnabled,
@@ -4706,6 +4716,7 @@ var setInternalState = (stateStr) => {
             (Math.cos(phase * 2 * Math.PI) - 1) / Math.PI;
         growthIntegral = time / 2 + 36 * Math.sin(time * Math.PI / 72) /
             Math.PI;
+        lastSave = state.time;
     }
     if ('plotIdx' in state)
         plotIdx = state.plotIdx;

--- a/theory.js
+++ b/theory.js
@@ -55,7 +55,7 @@ const LOC_STRINGS = {
         versionName: `Version: 0.1.2h1, Slumber Seeds`,
         wip: 'Work in Progress',
         currencyTax: 'p (tax)',
-        pubTax: 'Tax on publish',
+        pubTax: 'Publish tax',
         btnView: 'View L-system',
         btnVar: 'Variables',
         btnClose: 'Close',
@@ -195,23 +195,23 @@ type 1 travels up)\\\\—\\\\Harvest returns profit as the sum of all L.\\\\Prun
 cuts off all A and K.\\\\—\\\\The Model specification section may be ignored.`,
                 stages: {
                     index: [
-                        0, 4, 8, 9, 12, 13, 14, 17, 20,
-                        21, 22
+                        0, 4, 8, 10, 12, 14, 15, 18, 20,
+                        23, 24
                     ],
                     0: 'A seedling in its sweet slumber.',
                     4: 'The first pair of leaves pops up. A stem, as well.',
                     8: 'The second pair of leaves appears.',
-                    9: 'Little leaves start to grow over the first node.',
+                    10: 'Little leaves start to grow over the first node.',
                     12: 'The third pair of leaves appears.',
-                    13: 'Little leaves now grow over the second node.',
-                    14: 'This rhythm will repeat for a while.',
-                    17: `I'll show you what to do when it flowers, soon.`,
+                    14: 'Little leaves now grow over the second node.',
+                    15: 'This rhythm will repeat for a while.',
+                    18: `I'll show you what to do when it flowers, soon.`,
                     20: `It's about to flower. You can nip the stem now if you
 don't feel confident.`,
-                    21: `The first flower appears.`,
-                    22: `If the flower's still there, imagine it's sending a
-signal from top to bottom, all the way to basil base. Then, basil base will
-send another one back to the leaves.`,
+                    23: `The first flower will appear soon.`,
+                    24: `If the flower's there, imagine it's sending a signal
+from top to bottom, all the way to basil base. Then, basil base will send
+another one back to the leaves.`,
                 }
             },
             3: {
@@ -330,7 +330,7 @@ Here's a recipe to make some delicious calendula bread:`
                     `slightly intoxicating flavour.
 Even my dog loves it from time to time.
 
-Time to maturity: 6~7 weeks
+Time to maturity: 'I haven't timed it yet'
 
 If you intend to harvest, snip off the stem before it flowers. Otherwise, ` +
                     `the plant will go into the end of its life cycle, and the leaves will lose ` +
@@ -2666,15 +2666,14 @@ const plantData = {
     2: // Basil
     {
         system: new LSystem('BA(0.18, 0)', [
-            'A(r, t): r>=flowerThreshold = K(0)',
+            'A(r, t): r>=flowerThreshold = S(0)K(0.02, 8)',
             'A(r, t): t<3 = A(r+0.06, t+1)',
-            'A(r, t) = F(0.12, 1.44)[+L(0.06, min(r+0.06, maxLeafSize), 0)]/(180)[+L(0.06, min(r+0.06, maxLeafSize), 0)]/(90)I(0)A(r+0.06, 0)',
+            'A(r, t) = F(0.12, 1.44)[+[I(0)]T(0.2)L(0.06, min(r+0.12, maxLeafSize), 0)]/(180)[+L(0.06, min(r+0.12, maxLeafSize), 0)]/(90)A(r-0.06, 0)',
             'I(t) > S(type): type<=0 = S(type)I(t)',
-            'I(t): t<4 = I(t+1)',
-            'I(t) = F(0.12, 0.36)[+L(0.03, maxLeafSize/2, 0)]/(180)[+L(0.03, maxLeafSize/2, 0)]',
-            'K(t): t<=signalThreshold = S(0)/(90)[+K(1)][-K(1)]K(t+1)',
-            'K(t): t-2 = K(t+1)',
-            'K(t) = K(t+1)K(1)',
+            'I(t): t<5 = I(t+1)',
+            'I(t) = /(90)F(0.12, 0.72)T[+L(0.03, maxLeafSize/2, 0)]/(180)[+L(0.03, maxLeafSize/2, 0)]I(-6)',
+            'K(s, t): t>0 = K(s+0.02, 0)K(0.02, t-1)',
+            'K(s, t): s<1 = K(s+0.02, t)',
             'L(p, lim, s): s<1 && p<lim = L(p+0.03, lim, s)',
             'S(type) < L(p, lim, s): s<1 = L(p, p, 1)',
             'L(p, lim, s): s>=1 && p>0.06 = L(p-0.06, lim, s)',
@@ -2684,23 +2683,22 @@ const plantData = {
             'B > S(type): type<=0 = BS(1)',
             'F(l, lim): l<lim = F(l+0.12, lim)',
             '~> #= Model specification',
-            '~> K(t) = /(90)F(min(1.25, sqrt(t/4)))T(-0.2){[k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//k(sqrt(min(1, t/8)))//]}',
-            '~> k(size): size<1 = [++F(size/2).[-F(size/2).].]',
+            '~> K(t) = /(90)F(min(1.25, sqrt(t*2))){[k(min(0.75, t*4))//k(min(0.75, t*4))//k(min(0.75, t*4))//k(min(0.75, t*4))//k(min(0.75, t*4))//k(min(0.75, t*4))//]}',
+            '~> k(size): size<0.75 = [++F(size/2).[-F(size/2).].]',
             '~> k(size) = [++F(size/3).++[--F(size/2).][&F(size/2).].[^F(size/2).][--F(size/2).].[-F(size/2).].[F(size/2).].]',
-            '~> L(p, lim, s): s<1 = {\\(90)T(p*0.8)F(sqrt(p)).[-(48)F(p).+F(p).+&F(p).+F(p).][F(p)[&F(p)[F(p)[^F(p).].].].].[+(48)F(p).-F(p).-&F(p).-F(p).][F(p)[&F(p)[F(p)[^F(p).].].].]}',
-            '~> L(p, lim, s) = {\\(90)T(lim)F(sqrt(lim)).[--F(lim).+&F(lim).+&F(lim).+F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].].[++F(lim).-&F(lim).-&F(lim).-F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].]}',
-        ], 30, 0, 'BASIL', '+-&^/\\T', 1, {
-            'flowerThreshold': '1.38',
-            'maxLeafSize': '0.66',
-            'signalThreshold': '0'
+            '~> L(p, lim, s): s<1 = {[\\(90)T(p*0.9)F(sqrt(p)).[-(48)F(p).+F(p).+&F(p).+F(p).][F(p)[&F(p)[F(p)[^F(p).].].].].[+(48)F(p).-F(p).-&F(p).-F(p).][F(p)[&F(p)[F(p)[^F(p).].].].]]}',
+            '~> L(p, lim, s) = {[\\(90)T(lim*1.2)F(sqrt(lim)).[--F(lim).+&F(lim).+&F(lim).+F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].].[++F(lim).-&F(lim).-&F(lim).-F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].]]}',
+        ], 30, 0, 'BASIL', '+-&^/\\T', -0.16, {
+            'flowerThreshold': '0.96',
+            'maxLeafSize': '0.66'
         }),
-        maxStage: 54,
-        cost: new ExponentialCost(1, 1),
+        maxStage: 46,
+        cost: new ExponentialCost(1.25, 1),
         growthRate: BigNumber.FOUR,
-        growthCost: BigNumber.THREE,
+        growthCost: BigNumber.from(2.5),
         actions: [
             {
-                symbols: new Set('L'),
+                symbols: new Set('KL'),
                 // system: new LSystem('', ['L=']),
                 killColony: true
             },
@@ -2714,7 +2712,7 @@ const plantData = {
             'B': null,
             'F': [2, 2],
             'I': [0],
-            'K': [0],
+            'K': [2, 0],
             'L': [2, 2, 0],
             'S': [0],
             '/': [0]
@@ -2846,10 +2844,10 @@ const plantData = {
         system: new LSystem('BA(0.18, 0)', [
             'A(r, t): r>=flowerThreshold = S(0)K(0.02, 8)',
             'A(r, t): t<3 = A(r+0.06, t+1)',
-            'A(r, t) = F(0.12, 1.44)[+[I(0)]T(0.2)L(0.06, min(r+0.12, maxLeafSize), 0)]/(180)[+L(0.06, min(r+0.12, maxLeafSize), 0)]/(90)A(r-0.12, 0)',
+            'A(r, t) = F(0.12, 1.44)[+[I(0)]T(0.2)L(0.06, min(r+0.12, maxLeafSize), 0)]/(180)[+L(0.06, min(r+0.12, maxLeafSize), 0)]/(90)A(r-0.06, 0)',
             'I(t) > S(type): type<=0 = S(type)I(t)',
-            'I(t): t<7 = I(t+1)',
-            'I(t) = /(90)F(0.12, 0.72)T[+L(0.03, maxLeafSize/2, 0)]/(180)[+L(0.03, maxLeafSize/2, 0)]I(-8)',
+            'I(t): t<5 = I(t+1)',
+            'I(t) = /(90)F(0.12, 0.72)T[+L(0.03, maxLeafSize/2, 0)]/(180)[+L(0.03, maxLeafSize/2, 0)]I(-6)',
             'K(s, t): t>0 = K(s+0.02, 0)K(0.02, t-1)',
             'K(s, t): s<1 = K(s+0.02, t)',
             'L(p, lim, s): s<1 && p<lim = L(p+0.03, lim, s)',
@@ -2866,12 +2864,12 @@ const plantData = {
             '~> k(size) = [++F(size/3).++[--F(size/2).][&F(size/2).].[^F(size/2).][--F(size/2).].[-F(size/2).].[F(size/2).].]',
             '~> L(p, lim, s): s<1 = {[\\(90)T(p*0.9)F(sqrt(p)).[-(48)F(p).+F(p).+&F(p).+F(p).][F(p)[&F(p)[F(p)[^F(p).].].].].[+(48)F(p).-F(p).-&F(p).-F(p).][F(p)[&F(p)[F(p)[^F(p).].].].]]}',
             '~> L(p, lim, s) = {[\\(90)T(lim*1.2)F(sqrt(lim)).[--F(lim).+&F(lim).+&F(lim).+F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].].[++F(lim).-&F(lim).-&F(lim).-F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].]]}',
-        ], 30, 0, 'BASIL', '+-&^/\\T', -0.2, {
-            'flowerThreshold': '0.66',
+        ], 30, 0, 'BASIL', '+-&^/\\T', -0.16, {
+            'flowerThreshold': '0.96',
             'maxLeafSize': '0.66'
         }),
-        maxStage: 50,
-        cost: new ExponentialCost(1, 1),
+        maxStage: 46,
+        cost: new ExponentialCost(1.25, 1),
         growthRate: BigNumber.FOUR,
         growthCost: BigNumber.from(2.5),
         actions: [
@@ -2890,7 +2888,7 @@ const plantData = {
             'B': null,
             'F': [2, 2],
             'I': [0],
-            'K': [0],
+            'K': [2, 0],
             'L': [2, 2, 0],
             'S': [0],
             '/': [0]
@@ -2910,6 +2908,15 @@ const plantData = {
             };
         }
     },
+};
+// For reference only
+const plantIDLookup = {
+    calendula: 1,
+    basil: 2,
+    campion: 3,
+    rose: 3,
+    arrow: 9001,
+    brasil: 9002
 };
 let haxEnabled = false;
 let time = 0;
@@ -3472,8 +3479,7 @@ var getSecondaryEquation = () => {
         T_{\\text{p}}=${taxRate}\\times\\max\\text{p}\\\\\\\\`;
         let tauInfo = `${theory.latexSymbol}=\\max\\text{p}^
         ${tauRate.toString(0)}`;
-        return `\\begin{array}{c}${theory.publicationUpgrade.level &&
-            theory.canPublish ? taxInfo : ''}${tauInfo}\\end{array}`;
+        return `\\begin{array}{c}${taxInfo}${tauInfo}\\end{array}`;
     }
     switch (colonyMode) {
         case 1:

--- a/theory.js
+++ b/theory.js
@@ -192,9 +192,9 @@ known as the golden angle.`,
                 name: 'Basil',
                 info: 'A fast growing herb that requires a bit of care.',
                 LsDetails: `A: apex (stem shoot)\\\\B: base\\\\F: internode\\\\
-I : shortened stem\\\\K: flower\\\\L: leaf\\\\—\\\\Harvest returns profit as the
-sum of all L.\\\\Prune cuts off all A and K.\\\\—\\\\The Model specification
-section may be ignored.`,
+I : shortened stem\\\\K: flower\\\\L: leaf\\\\S: signal (type 0 travels down,
+type 1 travels up)\\\\—\\\\Harvest returns profit as the sum of all L.\\\\Prune
+cuts off all A and K.\\\\—\\\\The Model specification section may be ignored.`,
                 stages: {
                     index: [
                         0, 4, 8, 9, 12, 13, 14, 17, 20,
@@ -541,6 +541,9 @@ let getSmallBtnSize = (width) => {
     if (width >= 360)
         return 40;
     return 32;
+};
+let getProgBarSize = (width) => {
+    return getSmallBtnSize(width) / 2;
 };
 /**
  * Returns the index of the first smaller/equal element than target.
@@ -2669,6 +2672,7 @@ const plantData = {
             'I': [0],
             'K': [0],
             'L': [2, 2, 0],
+            'S': [0],
             '/': [0]
         },
         camera: (stage) => {
@@ -3864,7 +3868,7 @@ let createBookMenu = (book) => {
     let pageTitle = ui.createLatexLabel({
         text: pages[page].title,
         margin: new Thickness(0, 4),
-        heightRequest: 20,
+        heightRequest: getProgBarSize(ui.screenWidth),
         horizontalTextAlignment: TextAlignment.CENTER,
         verticalTextAlignment: TextAlignment.CENTER
     });

--- a/theory.js
+++ b/theory.js
@@ -22,14 +22,12 @@ import { Sound } from './api/Sound';
 import { game } from './api/Game';
 var id = 'lemmas_garden';
 var getName = (language) => {
-    var _a;
     const names = {
         en: `Lemma's Garden`,
     };
-    return (_a = names[language]) !== null && _a !== void 0 ? _a : names.en;
+    return names[language] ?? names.en;
 };
 var getDescription = (language) => {
-    var _a;
     const descs = {
         en: `Last night, Lemma didn't sweep away the rubbles on her old garden.
 You did. You are her first student in a long while.
@@ -37,7 +35,7 @@ You did. You are her first student in a long while.
 Welcome to Lemma's Garden, an idle botanical theory built on the grammar of ` +
             `Lindenmayer systems.`,
     };
-    return (_a = descs[language]) !== null && _a !== void 0 ? _a : descs.en;
+    return descs[language] ?? descs.en;
 };
 var authors = 'propfeds\n\nThanks to:\ngame-icons.net, for the icons';
 var version = 0.102;
@@ -49,7 +47,7 @@ const LS_CONTEXT = /((.)(\(([^\)]+)\))?<)?((.)(\(([^\)]+)\))?)(>(.)(\(([^\)]+)\)
 const BACKTRACK_LIST = new Set('+-&^\\/|[$T');
 // Leaves and apices
 const SYNTHABLE_SYMBOLS = new Set('AL');
-const MAX_CHARS_PER_TICK = 200;
+const MAX_CHARS_PER_TICK = 150;
 const NORMALISE_QUATERNIONS = false;
 const MENU_LANG = Localization.language;
 const LOC_STRINGS = {
@@ -245,6 +243,22 @@ for you?`
             },
             9001: {
                 name: '(Test) Arrow weed',
+                info: 'Not balanced for regular play.',
+                LsDetails: `The symbol A represents a rising shoot (apex), ` +
+                    `while F represents the stem body.\\\\The Prune (scissors) action cuts every ` +
+                    `F.\\\\The Harvest (bundle) action returns profit based on the sum of A, and ` +
+                    `kills the colony.`,
+                stages: {
+                    index: [0, 1, 2, 4],
+                    0: 'The first shoot rises.\\\\Already harvestable.',
+                    1: 'The shoot splits in three.\\\\The stem lengthens.',
+                    2: 'The shoots continue to divide.',
+                    4: `What do you expect? It\'s a fractal. Arrow weed is the
+friend of all mathematicians.`
+                }
+            },
+            9002: {
+                name: 'Brasil',
                 info: 'Not balanced for regular play.',
                 LsDetails: `The symbol A represents a rising shoot (apex), ` +
                     `while F represents the stem body.\\\\The Prune (scissors) action cuts every ` +
@@ -586,10 +600,9 @@ for (let i = 1; i <= 400; ++i) {
  */
 class Queue {
     constructor(object = {}) {
-        var _a, _b, _c;
-        this.oldestIndex = (_a = object.oldestIndex) !== null && _a !== void 0 ? _a : 0;
-        this.newestIndex = (_b = object.newestIndex) !== null && _b !== void 0 ? _b : 0;
-        this.storage = (_c = object.storage) !== null && _c !== void 0 ? _c : {};
+        this.oldestIndex = object.oldestIndex ?? 0;
+        this.newestIndex = object.newestIndex ?? 0;
+        this.storage = object.storage ?? {};
     }
     get length() {
         let result = this.newestIndex - this.oldestIndex;
@@ -1206,13 +1219,12 @@ class LSystem {
      * @returns {object}
      */
     getAncestree(sequence, task = {}) {
-        var _a, _b, _c, _d, _e;
         // Scanning behaviour should be very similar to renderer drawing.
-        let tmpStack = (_a = task.stack) !== null && _a !== void 0 ? _a : [];
-        let tmpIdxStack = (_b = task.idxStack) !== null && _b !== void 0 ? _b : [];
-        let tmpAncestors = (_c = task.ancestors) !== null && _c !== void 0 ? _c : [];
-        let tmpChildren = (_d = task.children) !== null && _d !== void 0 ? _d : [];
-        let i = (_e = task.start) !== null && _e !== void 0 ? _e : 0;
+        let tmpStack = task.stack ?? [];
+        let tmpIdxStack = task.idxStack ?? [];
+        let tmpAncestors = task.ancestors ?? [];
+        let tmpChildren = task.children ?? [];
+        let i = task.start ?? 0;
         for (; i < sequence.length; ++i) {
             if (i - task.start > MAX_CHARS_PER_TICK) {
                 return {
@@ -1267,10 +1279,9 @@ class LSystem {
      * the current tick. `start` denotes the next tick's starting position.
      */
     derive(sequence, seqParams, ancestors, children, task = {}) {
-        var _a, _b, _c, _d;
-        let result = (_a = task.derivation) !== null && _a !== void 0 ? _a : '';
-        let resultParams = (_b = task.parameters) !== null && _b !== void 0 ? _b : [];
-        let i = (_c = task.start) !== null && _c !== void 0 ? _c : 0;
+        let result = task.derivation ?? '';
+        let resultParams = task.parameters ?? [];
+        let i = task.start ?? 0;
         let charCount = 0;
         for (; i < sequence.length; ++i) {
             if (charCount > MAX_CHARS_PER_TICK) {
@@ -1325,12 +1336,10 @@ class LSystem {
                         if (right == -1)
                             continue;
                     }
-                    let tmpParamMap = (v) => {
-                        var _a;
-                        return (_a = this.varGetter(v)) !== null && _a !== void 0 ? _a : tmpRules[j].paramMap(v, seqParams[ancestors[i]], seqParams[i], seqParams[right]);
-                    };
+                    let tmpParamMap = (v) => this.varGetter(v) ??
+                        tmpRules[j].paramMap(v, seqParams[ancestors[i]], seqParams[i], seqParams[right]);
                     // Next up is the condition
-                    if ((_d = tmpRules[j].condition.evaluate(tmpParamMap)) === null || _d === void 0 ? void 0 : _d.isZero)
+                    if (tmpRules[j].condition.evaluate(tmpParamMap)?.isZero)
                         continue;
                     if (typeof tmpRules[j].derivations === 'string') {
                         result += tmpRules[j].derivations;
@@ -1420,18 +1429,15 @@ class LSystem {
         };
     }
     deriveModel(symbol, params) {
-        var _a;
         let result = '';
         let resultParams = [];
         if (this.models.has(symbol)) {
             let tmpRules = this.models.get(symbol);
             for (let j = 0; j < tmpRules.length; ++j) {
-                let tmpParamMap = (v) => {
-                    var _a;
-                    return (_a = this.varGetter(v)) !== null && _a !== void 0 ? _a : tmpRules[j].paramMap(v, null, null, params);
-                };
+                let tmpParamMap = (v) => this.varGetter(v) ??
+                    tmpRules[j].paramMap(v, null, null, params);
                 // Next up is the condition
-                if ((_a = tmpRules[j].condition.evaluate(tmpParamMap)) === null || _a === void 0 ? void 0 : _a.isZero)
+                if (tmpRules[j].condition.evaluate(tmpParamMap)?.isZero)
                     continue;
                 if (typeof tmpRules[j].derivations === 'string') {
                     result = tmpRules[j].derivations;
@@ -1515,7 +1521,6 @@ class LSystem {
      * @returns {{start: number, result: string}}
      */
     reconstruct(colony, filter = '', displayParams = true, task = {}) {
-        var _a, _b, _c, _d;
         let sequence = colony.sequence;
         let params = colony.params;
         let decimalTable = plantData[colony.id].decimals;
@@ -1526,8 +1531,8 @@ class LSystem {
             };
         }
         let filterSet = new Set(filter);
-        let result = (_a = task.result) !== null && _a !== void 0 ? _a : '';
-        let i = (_b = task.start) !== null && _b !== void 0 ? _b : 0;
+        let result = task.result ?? '';
+        let i = task.start ?? 0;
         for (; i < sequence.length; ++i) {
             if ((i - task.start) > MAX_CHARS_PER_TICK) {
                 return {
@@ -1538,10 +1543,10 @@ class LSystem {
             if (!filter || filterSet.has(sequence[i])) {
                 result += sequence[i];
                 if (displayParams && params[i]) {
-                    let charDT = (_c = decimalTable[sequence[i]]) !== null && _c !== void 0 ? _c : [];
+                    let charDT = decimalTable[sequence[i]] ?? [];
                     let paramStrings = [];
                     for (let j = 0; j < params[i].length; ++j)
-                        paramStrings[j] = params[i][j].toString((_d = charDT[j]) !== null && _d !== void 0 ? _d : 2);
+                        paramStrings[j] = params[i][j].toString(charDT[j] ?? 2);
                     result += `(${paramStrings.join(', ')})`;
                 }
                 // result += '\n';
@@ -1607,24 +1612,23 @@ class LSystem {
  */
 class Renderer {
     constructor(system, sequence, params, camera = {}, stroke = {}) {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
         this.figureScale = camera.scale || 1;
-        this.cameraMode = (_a = camera.mode) !== null && _a !== void 0 ? _a : 0;
-        this.followFactor = (_b = camera.followFactor) !== null && _b !== void 0 ? _b : 0.15;
-        this.camCentre = new Vector3((_c = camera.x) !== null && _c !== void 0 ? _c : 0, (_d = camera.y) !== null && _d !== void 0 ? _d : 0, (_e = camera.z) !== null && _e !== void 0 ? _e : 0);
-        this.upright = (_f = camera.upright) !== null && _f !== void 0 ? _f : false;
+        this.cameraMode = camera.mode ?? 0;
+        this.followFactor = camera.followFactor ?? 0.15;
+        this.camCentre = new Vector3(camera.x ?? 0, camera.y ?? 0, camera.z ?? 0);
+        this.upright = camera.upright ?? false;
         this.lastCamera = new Vector3(0, 0, 0);
         this.lastCamVel = new Vector3(0, 0, 0);
-        this.tickLength = (_g = stroke.tickLength) !== null && _g !== void 0 ? _g : 1;
-        this.initDelay = (_h = stroke.initDelay) !== null && _h !== void 0 ? _h : 0;
+        this.tickLength = stroke.tickLength ?? 1;
+        this.initDelay = stroke.initDelay ?? 0;
         // Loop mode is always 0
         // Whether to reset graph on hitting reset button is a game setting
-        this.loadModels = (_j = stroke.loadModels) !== null && _j !== void 0 ? _j : true;
-        this.quickDraw = (_k = stroke.quickDraw) !== null && _k !== void 0 ? _k : false;
-        this.quickBacktrack = (_l = stroke.quickBacktrack) !== null && _l !== void 0 ? _l : false;
-        this.backtrackTail = (_m = stroke.backtrackTail) !== null && _m !== void 0 ? _m : true;
-        this.hesitateApex = (_o = stroke.hesitateApex) !== null && _o !== void 0 ? _o : true;
-        this.hesitateFork = (_p = stroke.hesitateFork) !== null && _p !== void 0 ? _p : true;
+        this.loadModels = stroke.loadModels ?? true;
+        this.quickDraw = stroke.quickDraw ?? false;
+        this.quickBacktrack = stroke.quickBacktrack ?? false;
+        this.backtrackTail = stroke.backtrackTail ?? true;
+        this.hesitateApex = stroke.hesitateApex ?? true;
+        this.hesitateFork = stroke.hesitateFork ?? true;
         this.system = system;
         this.sequence = sequence;
         this.params = params;
@@ -1682,22 +1686,21 @@ class Renderer {
         this.configure(colony.sequence, colony.params, plantData[colony.id].camera(colony.stage), plantData[colony.id].stroke(colony.stage));
     }
     configure(sequence, params, camera = {}, stroke = {}) {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p;
         this.figureScale = camera.scale || 1;
-        this.cameraMode = (_a = camera.mode) !== null && _a !== void 0 ? _a : 0;
-        this.followFactor = (_b = camera.followFactor) !== null && _b !== void 0 ? _b : 0.15;
-        this.camCentre = new Vector3((_c = camera.x) !== null && _c !== void 0 ? _c : 0, (_d = camera.y) !== null && _d !== void 0 ? _d : 0, (_e = camera.z) !== null && _e !== void 0 ? _e : 0);
-        this.upright = (_f = camera.upright) !== null && _f !== void 0 ? _f : false;
-        this.tickLength = (_g = stroke.tickLength) !== null && _g !== void 0 ? _g : 1;
-        this.initDelay = (_h = stroke.initDelay) !== null && _h !== void 0 ? _h : 0;
+        this.cameraMode = camera.mode ?? 0;
+        this.followFactor = camera.followFactor ?? 0.15;
+        this.camCentre = new Vector3(camera.x ?? 0, camera.y ?? 0, camera.z ?? 0);
+        this.upright = camera.upright ?? false;
+        this.tickLength = stroke.tickLength ?? 1;
+        this.initDelay = stroke.initDelay ?? 0;
         // Loop mode is always 0
         // Whether to reset graph on hitting reset button is a game setting
-        this.loadModels = (_j = stroke.loadModels) !== null && _j !== void 0 ? _j : true;
-        this.quickDraw = (_k = stroke.quickDraw) !== null && _k !== void 0 ? _k : false;
-        this.quickBacktrack = (_l = stroke.quickBacktrack) !== null && _l !== void 0 ? _l : false;
-        this.backtrackTail = (_m = stroke.backtrackTail) !== null && _m !== void 0 ? _m : true;
-        this.hesitateApex = (_o = stroke.hesitateApex) !== null && _o !== void 0 ? _o : true;
-        this.hesitateFork = (_p = stroke.hesitateFork) !== null && _p !== void 0 ? _p : true;
+        this.loadModels = stroke.loadModels ?? true;
+        this.quickDraw = stroke.quickDraw ?? false;
+        this.quickBacktrack = stroke.quickBacktrack ?? false;
+        this.backtrackTail = stroke.backtrackTail ?? true;
+        this.hesitateApex = stroke.hesitateApex ?? true;
+        this.hesitateFork = stroke.hesitateFork ?? true;
         this.sequence = sequence;
         this.params = params;
         this.redrawing = true;
@@ -2135,30 +2138,35 @@ class Renderer {
 */
 class ColonyManager {
     constructor(object = {}, length, width) {
-        var _a, _b, _c, _d, _e, _f;
         this.length = length;
         this.width = width;
-        this.colonies = (_a = object.colonies) !== null && _a !== void 0 ? _a : Array.from({ length: this.length }, (_) => []);
+        this.colonies = object.colonies ??
+            Array.from({ length: this.length }, (_) => []);
         // Everyone gangsta until a colony starts evolving
         this.gangsta = object.gangsta;
-        this.ancestreeTask = (_b = object.ancestreeTask) !== null && _b !== void 0 ? _b : {
-            start: 0
-        };
-        this.deriveTask = (_c = object.deriveTask) !== null && _c !== void 0 ? _c : {
-            start: 0
-        };
-        this.calcTask = (_d = object.calcTask) !== null && _d !== void 0 ? _d : {
-            start: 0
-        };
+        this.ancestreeTask = object.ancestreeTask ??
+            {
+                start: 0
+            };
+        this.deriveTask = object.deriveTask ??
+            {
+                start: 0
+            };
+        this.calcTask = object.calcTask ??
+            {
+                start: 0
+            };
         // Processed before regular gangsta
         this.actionQueue = new Queue(object.actionQueue);
         this.actionGangsta = object.actionGangsta;
-        this.actionDeriveTask = (_e = object.actionDeriveTask) !== null && _e !== void 0 ? _e : {
-            start: 0
-        };
-        this.actionCalcTask = (_f = object.actionCalcTask) !== null && _f !== void 0 ? _f : {
-            start: 0
-        };
+        this.actionDeriveTask = object.actionDeriveTask ??
+            {
+                start: 0
+            };
+        this.actionCalcTask = object.actionCalcTask ??
+            {
+                start: 0
+            };
     }
     get object() {
         return {
@@ -2220,7 +2228,8 @@ class ColonyManager {
         let c = this.colonies[plot][index];
         if (!c)
             return;
-        plants[plot][c.id].level -= Math.min(plants[plot][c.id].level, c.population);
+        if (plantUnlocks.includes(c.id))
+            plants[plot][c.id].level -= Math.min(plants[plot][c.id].level, c.population);
         if (index == this.colonies[plot].length - 1)
             switchColony.buy(1);
         if (this.gangsta && plot == this.gangsta[0]) {
@@ -2248,7 +2257,6 @@ class ColonyManager {
         updateAvailability();
     }
     growAll(di, dg, dd) {
-        var _a;
         if (this.actionGangsta)
             this.continueAction();
         else if (this.actionQueue.length) {
@@ -2260,7 +2268,7 @@ class ColonyManager {
         for (let i = 0; i < this.colonies.length; ++i) {
             for (let j = 0; j < this.colonies[i].length; ++j) {
                 let c = this.colonies[i][j];
-                let notMature = c.stage < ((_a = plantData[c.id].maxStage) !== null && _a !== void 0 ? _a : MAX_INT);
+                let notMature = c.stage < (plantData[c.id].maxStage ?? MAX_INT);
                 // @ts-expect-error
                 if (notMature && c.growth >= plantData[c.id].growthCost *
                     // @ts-expect-error
@@ -2313,14 +2321,13 @@ class ColonyManager {
         }
     }
     calculateStats(colony, task = {}, dTask = {}) {
-        var _a, _b, _c, _d, _e;
         // This is the only case where the colony needed
         let harvestable = plantData[colony.id].actions[0].symbols;
-        let synthRate = (_a = task.synthRate) !== null && _a !== void 0 ? _a : BigNumber.ZERO;
-        let profit = (_b = task.profit) !== null && _b !== void 0 ? _b : BigNumber.ZERO;
-        let sequence = (_c = dTask.derivation) !== null && _c !== void 0 ? _c : colony.sequence;
-        let params = (_d = dTask.parameters) !== null && _d !== void 0 ? _d : colony.params;
-        let i = (_e = task.start) !== null && _e !== void 0 ? _e : 0;
+        let synthRate = task.synthRate ?? BigNumber.ZERO;
+        let profit = task.profit ?? BigNumber.ZERO;
+        let sequence = dTask.derivation ?? colony.sequence;
+        let params = dTask.parameters ?? colony.params;
+        let i = task.start ?? 0;
         for (; i < sequence.length; ++i) {
             if (i - task.start > MAX_CHARS_PER_TICK) {
                 return {
@@ -2512,20 +2519,57 @@ class Book {
     }
 }
 const almanac = new Book(getLoc('almanacTitle'), [
-    Object.assign(Object.assign({}, getLoc('almanac').cover), { horizontalAlignment: TextAlignment.CENTER }),
-    Object.assign(Object.assign({}, getLoc('almanac').prep), { pinned: true }),
-    Object.assign(Object.assign({}, getLoc('almanac')[1]), { systemID: 1, source: 'https://www.tasteofyummy.com/calendula-bread-for-bread-lovers/', pinned: true }),
-    Object.assign(Object.assign({}, getLoc('almanac')[2]), { systemID: 2, pinned: true }),
-    Object.assign(Object.assign({}, getLoc('almanac')[3]), { systemID: 3, pinned: true }),
+    {
+        ...getLoc('almanac').cover,
+        horizontalAlignment: TextAlignment.CENTER
+    },
+    {
+        ...getLoc('almanac').prep,
+        pinned: true
+    },
+    {
+        ...getLoc('almanac')[1],
+        systemID: 1,
+        source: 'https://www.tasteofyummy.com/calendula-bread-for-bread-lovers/',
+        pinned: true
+    },
+    {
+        ...getLoc('almanac')[2],
+        systemID: 2,
+        pinned: true
+    },
+    {
+        ...getLoc('almanac')[3],
+        systemID: 3,
+        pinned: true
+    },
 ]);
 const LsManual = new Book(getLoc('manualTitle'), [
     getLoc('manual').foreword,
-    Object.assign(Object.assign({}, getLoc('manual').cover), { horizontalAlignment: TextAlignment.CENTER }),
-    Object.assign(Object.assign({}, getLoc('manual').intro), { pinned: true }),
-    Object.assign(Object.assign({}, getLoc('manual').context), { pinned: true }),
-    Object.assign(Object.assign({}, getLoc('manual').parametric), { pinned: true }),
-    Object.assign(Object.assign({}, getLoc('manual').symbols), { pinned: true }),
-    Object.assign(Object.assign({}, getLoc('manual').turtleSymbols), { pinned: true }),
+    {
+        ...getLoc('manual').cover,
+        horizontalAlignment: TextAlignment.CENTER
+    },
+    {
+        ...getLoc('manual').intro,
+        pinned: true
+    },
+    {
+        ...getLoc('manual').context,
+        pinned: true
+    },
+    {
+        ...getLoc('manual').parametric,
+        pinned: true
+    },
+    {
+        ...getLoc('manual').symbols,
+        pinned: true
+    },
+    {
+        ...getLoc('manual').turtleSymbols,
+        pinned: true
+    },
 ]);
 // Balance parameters
 const nofPlots = 6;
@@ -2797,6 +2841,75 @@ const plantData = {
             };
         }
     },
+    9002: // BRasil (test)
+    {
+        system: new LSystem('BA(0.18, 0)', [
+            'A(r, t): r>=flowerThreshold = S(0)K(0.02, 8)',
+            'A(r, t): t<3 = A(r+0.06, t+1)',
+            'A(r, t) = F(0.12, 1.44)[+[I(0)]T(0.2)L(0.06, min(r+0.12, maxLeafSize), 0)]/(180)[+L(0.06, min(r+0.12, maxLeafSize), 0)]/(90)A(r-0.12, 0)',
+            'I(t) > S(type): type<=0 = S(type)I(t)',
+            'I(t): t<7 = I(t+1)',
+            'I(t) = /(90)F(0.12, 0.72)T[+L(0.03, maxLeafSize/2, 0)]/(180)[+L(0.03, maxLeafSize/2, 0)]I(-8)',
+            'K(s, t): t>0 = K(s+0.02, 0)K(0.02, t-1)',
+            'K(s, t): s<1 = K(s+0.02, t)',
+            'L(p, lim, s): s<1 && p<lim = L(p+0.03, lim, s)',
+            'S(type) < L(p, lim, s): s<1 = L(p, p, 1)',
+            'L(p, lim, s): s>=1 && p>0.06 = L(p-0.06, lim, s)',
+            'F(l, lim) > S(type): type<=0 = S(type)F(l, lim)',
+            'S(type) < F(l, lim): type>=1 = F(l, lim)S(type)',
+            'S(type) =',
+            'B > S(type): type<=0 = BS(1)',
+            'F(l, lim): l<lim = F(l+0.12, lim)',
+            '~> #= Model specification',
+            '~> K(t) = /(90)F(min(1.25, sqrt(t*2))){[k(min(0.75, t*3))//k(min(0.75, t*3))//k(min(0.75, t*3))//k(min(0.75, t*3))//k(min(0.75, t*3))//k(min(0.75, t*3))//]}',
+            '~> k(size): size<0.75 = [++F(size/2).[-F(size/2).].]',
+            '~> k(size) = [++F(size/3).++[--F(size/2).][&F(size/2).].[^F(size/2).][--F(size/2).].[-F(size/2).].[F(size/2).].]',
+            '~> L(p, lim, s): s<1 = {[\\(90)T(p*0.9)F(sqrt(p)).[-(48)F(p).+F(p).+&F(p).+F(p).][F(p)[&F(p)[F(p)[^F(p).].].].].[+(48)F(p).-F(p).-&F(p).-F(p).][F(p)[&F(p)[F(p)[^F(p).].].].]]}',
+            '~> L(p, lim, s) = {[\\(90)T(lim*1.2)F(sqrt(lim)).[--F(lim).+&F(lim).+&F(lim).+F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].].[++F(lim).-&F(lim).-&F(lim).-F(lim)..][F(lim)[&F(lim)[&F(lim)[&F(lim).].].].]]}',
+        ], 30, 0, 'BASIL', '+-&^/\\T', -0.2, {
+            'flowerThreshold': '0.66',
+            'maxLeafSize': '0.66'
+        }),
+        maxStage: 50,
+        cost: new ExponentialCost(1, 1),
+        growthRate: BigNumber.FOUR,
+        growthCost: BigNumber.from(2.5),
+        actions: [
+            {
+                symbols: new Set('KL'),
+                // system: new LSystem('', ['L=']),
+                killColony: true
+            },
+            {
+                system: new LSystem('', ['K=', 'A=']),
+                killColony: false
+            }
+        ],
+        decimals: {
+            'A': [2, 0],
+            'B': null,
+            'F': [2, 2],
+            'I': [0],
+            'K': [0],
+            'L': [2, 2, 0],
+            'S': [0],
+            '/': [0]
+        },
+        camera: (stage) => {
+            return {
+                scale: 8,
+                x: 0,
+                y: saturate(stage / 4, 5, 9),
+                Z: 0,
+                upright: true
+            };
+        },
+        stroke: (stage) => {
+            return {
+                tickLength: 1
+            };
+        }
+    },
 };
 let haxEnabled = false;
 let time = 0;
@@ -2856,9 +2969,12 @@ let createFramedButton = (params, margin, callback, image) => {
         }),
         borderColor: Color.BORDER
     });
-    return ui.createStackLayout(Object.assign(Object.assign({}, params), { children: [
+    return ui.createStackLayout({
+        ...params,
+        children: [
             frame
-        ], onTouched: (e) => {
+        ],
+        onTouched: (e) => {
             if (e.type == TouchType.PRESSED) {
                 frame.borderColor = Color.TRANSPARENT;
                 // frame.hasShadow = false;
@@ -2874,7 +2990,8 @@ let createFramedButton = (params, margin, callback, image) => {
                 frame.borderColor = Color.BORDER;
                 // frame.hasShadow = true;
             }
-        } }));
+        }
+    });
 };
 // const actionsLabel = ui.createLatexLabel
 // ({
@@ -3509,7 +3626,6 @@ let createVariableMenu = (variables) => {
     return menu;
 };
 let createSystemMenu = (id) => {
-    var _a, _b, _c, _d;
     let values = plantData[id].system.object;
     let tmpAxiom = values.axiom;
     let axiomEntry = ui.createEntry({
@@ -3548,28 +3664,28 @@ let createSystemMenu = (id) => {
     let ruleStack = ui.createGrid({
         children: ruleEntries
     });
-    let tmpIgnore = (_a = values.ignoreList) !== null && _a !== void 0 ? _a : '';
+    let tmpIgnore = values.ignoreList ?? '';
     let ignoreEntry = ui.createEntry({
         text: tmpIgnore,
         row: 0,
         column: 1,
         horizontalTextAlignment: TextAlignment.END
     });
-    let tmpCI = (_b = values.ctxIgnoreList) !== null && _b !== void 0 ? _b : '';
+    let tmpCI = values.ctxIgnoreList ?? '';
     let CIEntry = ui.createEntry({
         text: tmpCI,
         row: 1,
         column: 1,
         horizontalTextAlignment: TextAlignment.END
     });
-    let tmpAngle = (_c = values.turnAngle) !== null && _c !== void 0 ? _c : '0';
+    let tmpAngle = values.turnAngle ?? '0';
     let angleEntry = ui.createEntry({
         text: tmpAngle.toString(),
         row: 2,
         column: 1,
         horizontalTextAlignment: TextAlignment.END
     });
-    let tmpTropism = (_d = values.tropism) !== null && _d !== void 0 ? _d : '0';
+    let tmpTropism = values.tropism ?? '0';
     let tropismEntry = ui.createEntry({
         text: tmpTropism.toString(),
         row: 3,
@@ -3694,7 +3810,6 @@ let createSystemMenu = (id) => {
     return menu;
 };
 let createColonyViewMenu = (colony) => {
-    var _a;
     if (!colonyViewConfig[colony.id]) {
         colonyViewConfig[colony.id] =
             {
@@ -3757,7 +3872,7 @@ let createColonyViewMenu = (colony) => {
     };
     let tmpCmt = updateCommentary();
     let plantStats = ui.createLatexLabel({
-        text: Localization.format(getLoc('plantStats'), cmtStage, tmpCmt, (_a = plantData[colony.id].maxStage) !== null && _a !== void 0 ? _a : '∞', colony.synthRate, plantData[colony.id].growthRate, plantData[colony.id].growthCost, colony.sequence.length),
+        text: Localization.format(getLoc('plantStats'), cmtStage, tmpCmt, plantData[colony.id].maxStage ?? '∞', colony.synthRate, plantData[colony.id].growthRate, plantData[colony.id].growthCost, colony.sequence.length),
         margin: new Thickness(0, 6),
         horizontalTextAlignment: TextAlignment.START,
         verticalTextAlignment: TextAlignment.CENTER
@@ -3787,7 +3902,6 @@ let createColonyViewMenu = (colony) => {
     });
     let menu = ui.createPopup({
         title: () => {
-            var _a;
             if (tmpStage != colony.stage) {
                 /*
                 Menu title and commentary are updated dynamically without
@@ -3795,7 +3909,7 @@ let createColonyViewMenu = (colony) => {
                 */
                 tmpTitle = Localization.format(getLoc('colony'), colony.population, getLoc('plants')[colony.id].name, colony.stage);
                 tmpCmt = updateCommentary();
-                plantStats.text = Localization.format(getLoc('plantStats'), cmtStage, tmpCmt, (_a = plantData[colony.id].maxStage) !== null && _a !== void 0 ? _a : '∞', colony.synthRate, plantData[colony.id].growthRate, plantData[colony.id].growthCost, colony.sequence.length);
+                plantStats.text = Localization.format(getLoc('plantStats'), cmtStage, tmpCmt, plantData[colony.id].maxStage ?? '∞', colony.synthRate, plantData[colony.id].growthRate, plantData[colony.id].growthCost, colony.sequence.length);
                 tmpStage = colony.stage;
                 reconstructionTask =
                     {
@@ -3860,7 +3974,6 @@ let createColonyViewMenu = (colony) => {
     return menu;
 };
 let createBookMenu = (book) => {
-    var _a, _b;
     let title = book.title;
     let pages = book.pages;
     let tableofContents = book.tableofContents;
@@ -3876,8 +3989,10 @@ let createBookMenu = (book) => {
         fontFamily: FontFamily.CMU_REGULAR,
         fontSize: 16,
         text: pages[page].contents,
-        horizontalTextAlignment: (_a = pages[page].horizontalAlignment) !== null && _a !== void 0 ? _a : TextAlignment.START,
-        verticalTextAlignment: (_b = pages[page].verticalAlignment) !== null && _b !== void 0 ? _b : TextAlignment.START
+        horizontalTextAlignment: pages[page].horizontalAlignment ??
+            TextAlignment.START,
+        verticalTextAlignment: pages[page].verticalAlignment ??
+            TextAlignment.START
     });
     let sourceEntry = ui.createEntry({
         row: 0,
@@ -3942,14 +4057,14 @@ let createBookMenu = (book) => {
         }
     });
     let setPage = (p) => {
-        var _a, _b;
         page = p;
         menu.title = Localization.format(getLoc('bookTitleFormat'), title, page + 1, pages.length);
         pageTitle.text = pages[page].title;
         pageContents.text = pages[page].contents;
         pageContents.horizontalTextAlignment =
-            (_a = pages[page].horizontalAlignment) !== null && _a !== void 0 ? _a : TextAlignment.START;
-        pageContents.verticalTextAlignment = (_b = pages[page].verticalAlignment) !== null && _b !== void 0 ? _b : TextAlignment.START;
+            pages[page].horizontalAlignment ?? TextAlignment.START;
+        pageContents.verticalTextAlignment = pages[page].verticalAlignment ??
+            TextAlignment.START;
         sourceGrid.isVisible = 'source' in pages[page];
         sourceEntry.text = 'source' in pages[page] ? pages[page].source : '';
         prevButton.isVisible = page > 0;
@@ -4050,8 +4165,7 @@ let createNotebookMenu = () => {
             keyboard: Keyboard.NUMERIC,
             horizontalTextAlignment: TextAlignment.END,
             onTextChanged: (ot, nt) => {
-                var _a;
-                let tmpML = (_a = Number(nt)) !== null && _a !== void 0 ? _a : MAX_INT;
+                let tmpML = Number(nt) ?? MAX_INT;
                 for (let j = 0; j < nofPlots; ++j) {
                     let count = 0;
                     for (let k = 0; k < manager.colonies[j].length; ++k) {
@@ -4498,7 +4612,7 @@ let bigStringify = (_, val) => {
         if (val instanceof BigNumber)
             return 'BigNumber' + val.toBase64String();
     }
-    catch (_a) { }
+    catch { }
     ;
     return val;
 };

--- a/theory.js
+++ b/theory.js
@@ -3791,7 +3791,7 @@ let createColonyViewMenu = (colony) => {
                 */
                 tmpTitle = Localization.format(getLoc('colony'), colony.population, getLoc('plants')[colony.id].name, colony.stage);
                 tmpCmt = updateCommentary();
-                plantStats.text = Localization.format(getLoc('plantStats'), cmtStage, tmpCmt, (_a = plantData[colony.id].maxStage) !== null && _a !== void 0 ? _a : '∞', plantData[colony.id].growthRate, colony.synthRate, plantData[colony.id].growthCost, colony.sequence.length);
+                plantStats.text = Localization.format(getLoc('plantStats'), cmtStage, tmpCmt, (_a = plantData[colony.id].maxStage) !== null && _a !== void 0 ? _a : '∞', colony.synthRate, plantData[colony.id].growthRate, plantData[colony.id].growthCost, colony.sequence.length);
                 tmpStage = colony.stage;
                 reconstructionTask =
                     {

--- a/theory.js
+++ b/theory.js
@@ -4529,7 +4529,7 @@ let createWorldMenu = () => {
                 e.type == TouchType.LONGPRESS_RELEASED) {
                 Sound.playClick();
                 actionConfirm = !actionConfirm;
-                APSwitch.isToggled = actionConfirm;
+                ACSwitch.isToggled = actionConfirm;
             }
         }
     });
@@ -4751,6 +4751,7 @@ var setInternalState = (stateStr) => {
         colonyMode = state.settings.colonyMode;
         fancyPlotTitle = state.settings.fancyPlotTitle;
         actionPanelOnTop = state.settings.actionPanelOnTop;
+        actionConfirm = state.settings.actionConfirm;
     }
     if ('colonyViewConfig' in state)
         colonyViewConfig = state.colonyViewConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "rootDir": "./src",
         "outDir": "./",
         // "allowJs": true,
-        "target": "ES2017"
+        "target": "ES2020"
     },
     "exclude": ["../api"]
 }


### PR DESCRIPTION
Balance changes:
- Basil:
  - Apex now decreases synthesis when it spawns new leaves.
  - Side stem now grows extra leaves.
  - Postponed flower spawn by a few stages.
  - Flowers now only grow in 1 clump, and give profit.
  - Max stage: 54 → 46
  - Growth cost: 3 → 2.5
  - Starting cost: 1 → 1.25
- Rose campion:
  - Max stage: 30 → 28
  - Growth cost: 2.5 → 5
  - Now grants income per stage instead of per night.
As with every change to plants, they have to be planted anew to take effect.

QoL changes:
- Added activity indicator (loading swirl) when the manager is busy.
- Internal state will not save while the manager is busy, to avoid maximum statements.
- Added a label to indicate time elapsed since last save.
- Added back old colony format under 'Single 2'.
- Added argument for force splitting in `addColony()` for testing.
- Fixed testing plants being unable to harvest.
- Fixed synth & growth rates swapped in colony menu after evolving.
- Fixed book title label clipping.
- Fixed action confirm switch and setting not working.