### PR TITLE
v0.2.1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -92,6 +92,9 @@ do nothing. Do you feel like it could be more interesting?
 - [ ] Align the vibes of basil & campion to make it feel smoother
 
 - [x] Rose campion as first bush plant
+  - [x] Nerf spreading rate to 1/2 or sth?
+  - [ ] Make it easy to calculate profit sum
+  - [ ] Change the propagation stage since fruit only starts generating at 19?
   - [ ] Maximum statements
   - [ ] Death? Propagation?
   - [ ] Shrub form?
@@ -99,15 +102,18 @@ do nothing. Do you feel like it could be more interesting?
   - [x] Income per evolution instead of night
   - [ ] Double growth cost
   - [ ] Flower turns into fruit faster
-  - [ ] Fruit falls off
+  - [x] Fruit falls off
   - [ ] Loading SLOW
-  - [ ] How long does it live? When does it spread seeds?
-  - [ ] Cost increases when it spreads, so need to shovel old ones before new
-  - [ ] Propagation ratio: 0.5, rounded up
   - [ ] Add a parameter to adjust stagely income multiplier (1/2x for now?)
   - [x] Passive income
   - [x] Nerf growth cost from 4 to 5? Stage 21 is so fast, how about 28?
   - [x] Extend rose campion seed period by a few stages
+
+- Calendula
+  - [x] Nerf spread rate to 1/3? Sum equals 1.5 making the pub mult coefficient 2 instead of 1.8
+
+- [ ] Change /sec indicators to /hr (in-game) and display 5x the value
+  - Counter-argument: all parameters display /sec
 
 ## v0.2: Education edition
 

--- a/src/theory.ts
+++ b/src/theory.ts
@@ -53,7 +53,7 @@ Welcome to Lemma's Garden, an idle botanical theory built on the grammar of ` +
     return descs[language] ?? descs.en;
 }
 var authors = 'propfeds\n\nThanks to:\ngame-icons.net, for the icons';
-var version = 0.2;
+var version = 0.21;
 
 // Numbers are often converted into 32-bit signed integers in JINT.
 const INT_MAX = 0x7fffffff;
@@ -73,7 +73,7 @@ const LOC_STRINGS =
 {
     en:
     {
-        versionName: `Version: 0.2, Less Dry`,
+        versionName: `Version: 0.2.1, 'Less Dry'`,
         wip: 'Work in Progress',
 
         currencyTax: 'p (tax)',
@@ -127,8 +127,9 @@ symbol is drawn depending on its parameters.`,
         unlockPlots: `\\text{{plots }}{{{0}}}~{{{1}}}`,
         unlockPlant: `\\text{{a new plant}}`,
         lockedPlot: `\\text{Untilled soil.}`,
-        permaNote: 'Notebook',
-        permaNoteInfo: 'Manage populations and harvests',
+        permaNote: `Notebook \\&\\ 'Buy All' button`,
+        permaNoteInfo: `Allows management of colony sizes (non-propagated)`,
+        menuNote: 'Notebook',
         permaSettings: 'Theory settings',
         permaSettingsInfo: `Decorate your teacher's garden`,
         labelPlants: 'Plants',
@@ -293,7 +294,7 @@ Decorative.\\\\—\\\\Harvest returns profit as the sum of all K sizes
                         0, 6, 9,
                         10, 14,
                         19,
-                        22
+                        22, 27
                     ],
                     0: 'A seedling basking in its own dazing lullaby.',
                     6: 'A flower bud already?',
@@ -304,7 +305,9 @@ counting pennies in the middle of the night?`,
 periodically.`,
                     19: `You see the first fruit on that stem?\\\\Too late for
 munch.`,
-                    22: `Go to sleep. Was my campion sedative not good enough?`
+                    22: `Go to sleep. Was my campion sedative not good enough?`,
+                    27: `A fruit falls off. Did you know that campion is a good
+self-seeder?`
                 }
             },
             arrow:
@@ -328,7 +331,7 @@ friend of all mathematicians.`
             },
         },
         plantStats: `({0}) {1}\\\\—\\\\Max. stage: {2}\\\\Synthesis rate: ` +
-`{3}/s (noon)\\\\Avg. growth rate: {4}/s\\\\Growth cost: {5} × {6} ` +
+`{3}/s (noon)\\\\Growth rate: {4}/s\\\\Growth cost: {5} × {6} ` +
 `symbols\\\\—\\\\Sequence:`,
         noCommentary: 'No commentary.',
         noLsDetails: 'No explanations.',
@@ -439,7 +442,7 @@ The 'pot' in its name should also suggest it's uses as a cooking herb in ` +
 `stews and soups too.
 
 Life span: annual
-Propagation: At life cycle's end, spread 40% of the current population onto ` +
+Propagation: At life cycle's end, spread 1/3 of the current population onto ` +
 `the same plot.
 
 Here's a recipe to make some delicious calendula bread for your pleasures too:`
@@ -476,7 +479,7 @@ Occasionally, visitors and artists, generous donors, they would come and ` +
 `there is the occasional human too.
 
 Life span: biennial
-Propagation: In the latter half of its life cycle, spread 60% of the current ` +
+Propagation: In the latter half of its life cycle, spread 1/2 of the current ` +
 `population onto the same plot.
 Passively provides income per stage equal to its current profit.`
             }
@@ -3809,12 +3812,12 @@ const waterAmount = BigNumber.ONE;
 const plotCosts = new FirstFreeCost(new ExponentialCost(900, Math.log2(120)));
 const plantUnlocks = ['calendula', 'basil', 'campion'];
 const plantUnlockCosts = new CompositeCost(1,
-new ConstantCost(2200),
+new ConstantCost(2100),
 new ConstantCost(145000));
 const permaCosts =
 [
     BigNumber.from(27),
-    BigNumber.from(4800),
+    BigNumber.from(3600),
     BigNumber.from(1e45)
 ];
 
@@ -3874,7 +3877,7 @@ const plantData: {[key: string]: Plant} =
         waterCD: 3 * dayLength,
         propagation:
         {
-            rate: 0.4,
+            rate: 1/3,
             priority: 'c'
         },
         actions:
@@ -4002,7 +4005,8 @@ const plantData: {[key: string]: Plant} =
             'K(p, t): t<12 = K(1.35*p-0.8*p^2, t+1)',
             'K(p, t) = O(1)',
             'L(s): s<maxLeafSize = L(s+0.025)',
-            'O(s): s>0.6 = O(s*0.9)',
+            'O(s): s>0.5 = O(s*0.9)',
+            'O(s) =',
             'F(l, t): t>0 = F(l+0.4, t-1)'
         ], 31, 0, 'A', '', -0.6, {
             'maxLeafSize': '0.625'
@@ -4016,7 +4020,7 @@ const plantData: {[key: string]: Plant} =
             '~> L(s) = {T(s*0.5)F(sqrt(s)).[-(48)F(s*2).+F(s*2).+&F(s*2).+F(s*2).][F(s*2)[&F(s*2)[F(s*2)[^F(s*2).].].].].[+(48)F(s*2).-F(s*2).-&F(s*2).-F(s*2).][F(s*2)[&F(s*2)[F(s*2)[^F(s*2).].].].]}',
             '~> O(s) = {[+(10)c(s).[-(75)F(s).].]./(72)[+(10)c(s).[-(75)F(s).].]./(72)[+(10)c(s).[-(75)F(s).].]./(72)[+(10)c(s).[-(75)F(s).].]./(72)[+(10)c(s).[-(75)F(s).].].}'
         ]),
-        maxStage: 28,
+        maxStage: 29,
         cost: new ExponentialCost(2000, Math.log2(5)),
         growthRate: BigNumber.from(2.75),
         growthCost: BigNumber.TEN,//BigNumber.from(2.5),
@@ -4024,8 +4028,8 @@ const plantData: {[key: string]: Plant} =
         stagelyIncome: BigNumber.ONE,
         propagation:
         {
-            stage: 20,
-            rate: 0.6,
+            stage: 27,
+            rate: 1/2,
             priority: 'c'
         },
         actions:
@@ -4645,7 +4649,15 @@ var init = () =>
             plants[i][plantUnlocks[j]].bought = (amount: number) =>
             {
                 if(actuallyPlanting)
-                    manager.addColony(i, plantUnlocks[j], amount);
+                {
+                    // Check notebook for max level
+                    if(theory.isBuyAllAvailable && notebook[plantUnlocks[j]] &&
+                    plants[i][plantUnlocks[j]].level >
+                    notebook[plantUnlocks[j]].maxLevel)
+                        plants[i][plantUnlocks[j]].refund(amount);
+                    else
+                        manager.addColony(i, plantUnlocks[j], amount);
+                }
             };
             plants[i][plantUnlocks[j]].isAvailable = false;
         }
@@ -4750,7 +4762,10 @@ var init = () =>
     theory.createPublicationUpgrade(1, currency, permaCosts[0]);
     theory.publicationUpgrade.bought = (_) =>
     theory.invalidateQuaternaryValues();
+
     theory.createBuyAllUpgrade(2, currency, permaCosts[1]);
+    theory.buyAllUpgrade.description = getLoc('permaNote');
+    theory.buyAllUpgrade.info = getLoc('permaNoteInfo');
     // theory.createAutoBuyerUpgrade(3, currency, permaCosts[2]);
 
     /* Pause
@@ -4789,9 +4804,9 @@ var init = () =>
     {
         warpTick = theory.createPermanentUpgrade(9004, currency,
         new FreeCost);
-        warpTick.description = 'Warp 1.5 minutes';
-        warpTick.info = 'Warps forward by 0.15 time units';
-        warpTick.bought = (_) => tick(0.15, 1);
+        warpTick.description = 'Warp tick';
+        warpTick.info = 'Warps forward by a tick';
+        warpTick.bought = (_) => tick(0.1, 1);
         warpTick.isAvailable = haxEnabled;
     }
     /* Warp one
@@ -4800,9 +4815,9 @@ var init = () =>
     {
         warpDay = theory.createPermanentUpgrade(9003, currency,
         new FreeCost);
-        warpDay.description = 'Warp one day';
+        warpDay.description = 'Warp day';
         warpDay.info = 'Warps forward by a day';
-        warpDay.bought = (_) => tick(dayLength, 1);
+        warpDay.bought = (_) => tick(dayLength / speeds[speedIdx], 1);
         warpDay.isAvailable = haxEnabled;
     }
     /* Warp year
@@ -4811,9 +4826,9 @@ var init = () =>
     {
         warpYear = theory.createPermanentUpgrade(9005, currency,
         new FreeCost);
-        warpYear.description = 'Warp one year';
+        warpYear.description = 'Warp year';
         warpYear.info = 'Warps forward by 365 days';
-        warpYear.bought = (_) => tick(dayLength * 365, 1);
+        warpYear.bought = (_) => tick(dayLength * 365 / speeds[speedIdx], 1);
         warpYear.isAvailable = haxEnabled;
     }
     /* Warp zero
@@ -6007,22 +6022,9 @@ let createNotebookMenu = () =>
             onTextChanged: (ot: string, nt: string) =>
             {
                 let tmpML = Number(nt) ?? INT_MAX;
-                for(let j = 0; j < nofPlots; ++j)
-                {
-                    let count = 0;
-                    for(let k = 0; k < manager.colonies[j].length; ++k)
-                    {
-                        let c = manager.colonies[j][k];
-                        if(c.id == plantUnlocks[i] && !c.propagated)
-                        {
-                            count += c.population;
-                            tmpML = Math.max(tmpML, count);
-                        }
-                    }
-                }
                 notebook[plantUnlocks[i]].maxLevel = tmpML;
-                for(let j = 0; j < nofPlots; ++j)
-                    plants[j][plantUnlocks[i]].maxLevel = tmpML;
+                // for(let j = 0; j < nofPlots; ++j)
+                //     plants[j][plantUnlocks[i]].maxLevel = tmpML;
             }
         });
         let tmpMinusBtn = ui.createButton
@@ -6077,7 +6079,7 @@ let createNotebookMenu = () =>
     let menu = ui.createPopup
     ({
         isPeekable: true,
-        title: getLoc('permaNote'),
+        title: getLoc('menuNote'),
         content: ui.createStackLayout
         ({
             children:
@@ -6173,7 +6175,7 @@ let createShelfMenu = () =>
                 ui.createButton
                 ({
                     isVisible: theory.isBuyAllAvailable,
-                    text: getLoc('permaNote'),
+                    text: getLoc('menuNote'),
                     onClicked: () =>
                     {
                         Sound.playClick();
@@ -6798,12 +6800,12 @@ var setInternalState = (stateStr: string) =>
         for(let j = 0; j < plantUnlocks.length; ++j)
         {
             plants[i][plantUnlocks[j]].level = tmpLevels[i][plantUnlocks[j]];
-            if(theory.isBuyAllAvailable && notebook[plantUnlocks[j]])
-            {
-                plants[i][plantUnlocks[j]].maxLevel = Math.max(
-                notebook[plantUnlocks[j]].maxLevel,
-                plants[i][plantUnlocks[j]].level);
-            }
+            // if(theory.isBuyAllAvailable && notebook[plantUnlocks[j]])
+            // {
+            //     plants[i][plantUnlocks[j]].maxLevel = Math.max(
+            //     notebook[plantUnlocks[j]].maxLevel,
+            //     plants[i][plantUnlocks[j]].level);
+            // }
         }
     }
     actuallyPlanting = true;

--- a/theory.js
+++ b/theory.js
@@ -39,7 +39,7 @@ Welcome to Lemma's Garden, an idle botanical theory built on the grammar of ` +
     return descs[language] ?? descs.en;
 };
 var authors = 'propfeds\n\nThanks to:\ngame-icons.net, for the icons';
-var version = 0.2;
+var version = 0.21;
 // Numbers are often converted into 32-bit signed integers in JINT.
 const INT_MAX = 0x7fffffff;
 const INT_MIN = -0x80000000;
@@ -55,7 +55,7 @@ const NORMALISE_QUATERNIONS = false;
 const MENU_LANG = Localization.language;
 const LOC_STRINGS = {
     en: {
-        versionName: `Version: 0.2, Less Dry`,
+        versionName: `Version: 0.2.1, 'Less Dry'`,
         wip: 'Work in Progress',
         currencyTax: 'p (tax)',
         pubTax: 'Tax on publish\\colon',
@@ -103,8 +103,9 @@ symbol is drawn depending on its parameters.`,
         unlockPlots: `\\text{{plots }}{{{0}}}~{{{1}}}`,
         unlockPlant: `\\text{{a new plant}}`,
         lockedPlot: `\\text{Untilled soil.}`,
-        permaNote: 'Notebook',
-        permaNoteInfo: 'Manage populations and harvests',
+        permaNote: `Notebook \\&\\ 'Buy All' button`,
+        permaNoteInfo: `Allows management of colony sizes (non-propagated)`,
+        menuNote: 'Notebook',
         permaSettings: 'Theory settings',
         permaSettingsInfo: `Decorate your teacher's garden`,
         labelPlants: 'Plants',
@@ -248,7 +249,7 @@ Decorative.\\\\—\\\\Harvest returns profit as the sum of all K sizes
                         0, 6, 9,
                         10, 14,
                         19,
-                        22
+                        22, 27
                     ],
                     0: 'A seedling basking in its own dazing lullaby.',
                     6: 'A flower bud already?',
@@ -259,7 +260,9 @@ counting pennies in the middle of the night?`,
 periodically.`,
                     19: `You see the first fruit on that stem?\\\\Too late for
 munch.`,
-                    22: `Go to sleep. Was my campion sedative not good enough?`
+                    22: `Go to sleep. Was my campion sedative not good enough?`,
+                    27: `A fruit falls off. Did you know that campion is a good
+self-seeder?`
                 }
             },
             arrow: {
@@ -281,7 +284,7 @@ friend of all mathematicians.`
             },
         },
         plantStats: `({0}) {1}\\\\—\\\\Max. stage: {2}\\\\Synthesis rate: ` +
-            `{3}/s (noon)\\\\Avg. growth rate: {4}/s\\\\Growth cost: {5} × {6} ` +
+            `{3}/s (noon)\\\\Growth rate: {4}/s\\\\Growth cost: {5} × {6} ` +
             `symbols\\\\—\\\\Sequence:`,
         noCommentary: 'No commentary.',
         noLsDetails: 'No explanations.',
@@ -379,7 +382,7 @@ The 'pot' in its name should also suggest it's uses as a cooking herb in ` +
                     `stews and soups too.
 
 Life span: annual
-Propagation: At life cycle's end, spread 40% of the current population onto ` +
+Propagation: At life cycle's end, spread 1/3 of the current population onto ` +
                     `the same plot.
 
 Here's a recipe to make some delicious calendula bread for your pleasures too:`
@@ -412,7 +415,7 @@ Occasionally, visitors and artists, generous donors, they would come and ` +
                     `there is the occasional human too.
 
 Life span: biennial
-Propagation: In the latter half of its life cycle, spread 60% of the current ` +
+Propagation: In the latter half of its life cycle, spread 1/2 of the current ` +
                     `population onto the same plot.
 Passively provides income per stage equal to its current profit.`
             }
@@ -2898,10 +2901,10 @@ const maxColoniesPerPlot = 4;
 const waterAmount = BigNumber.ONE;
 const plotCosts = new FirstFreeCost(new ExponentialCost(900, Math.log2(120)));
 const plantUnlocks = ['calendula', 'basil', 'campion'];
-const plantUnlockCosts = new CompositeCost(1, new ConstantCost(2200), new ConstantCost(145000));
+const plantUnlockCosts = new CompositeCost(1, new ConstantCost(2100), new ConstantCost(145000));
 const permaCosts = [
     BigNumber.from(27),
-    BigNumber.from(4800),
+    BigNumber.from(3600),
     BigNumber.from(1e45)
 ];
 const taxRate = BigNumber.from(-.12);
@@ -2954,7 +2957,7 @@ const plantData = {
         growthCost: BigNumber.from(2.5),
         waterCD: 3 * dayLength,
         propagation: {
-            rate: 0.4,
+            rate: 1 / 3,
             priority: 'c'
         },
         actions: [
@@ -3069,7 +3072,8 @@ const plantData = {
             'K(p, t): t<12 = K(1.35*p-0.8*p^2, t+1)',
             'K(p, t) = O(1)',
             'L(s): s<maxLeafSize = L(s+0.025)',
-            'O(s): s>0.6 = O(s*0.9)',
+            'O(s): s>0.5 = O(s*0.9)',
+            'O(s) =',
             'F(l, t): t>0 = F(l+0.4, t-1)'
         ], 31, 0, 'A', '', -0.6, {
             'maxLeafSize': '0.625'
@@ -3082,15 +3086,15 @@ const plantData = {
             '~> L(s) = {T(s*0.5)F(sqrt(s)).[-(48)F(s*2).+F(s*2).+&F(s*2).+F(s*2).][F(s*2)[&F(s*2)[F(s*2)[^F(s*2).].].].].[+(48)F(s*2).-F(s*2).-&F(s*2).-F(s*2).][F(s*2)[&F(s*2)[F(s*2)[^F(s*2).].].].]}',
             '~> O(s) = {[+(10)c(s).[-(75)F(s).].]./(72)[+(10)c(s).[-(75)F(s).].]./(72)[+(10)c(s).[-(75)F(s).].]./(72)[+(10)c(s).[-(75)F(s).].]./(72)[+(10)c(s).[-(75)F(s).].].}'
         ]),
-        maxStage: 28,
+        maxStage: 29,
         cost: new ExponentialCost(2000, Math.log2(5)),
         growthRate: BigNumber.from(2.75),
         growthCost: BigNumber.TEN,
         waterCD: 5 * dayLength,
         stagelyIncome: BigNumber.ONE,
         propagation: {
-            stage: 20,
-            rate: 0.6,
+            stage: 27,
+            rate: 1 / 2,
             priority: 'c'
         },
         actions: [
@@ -3583,8 +3587,15 @@ var init = () => {
             plants[i][plantUnlocks[j]].info = getLoc('plants')[plantUnlocks[j]].
                 info;
             plants[i][plantUnlocks[j]].bought = (amount) => {
-                if (actuallyPlanting)
-                    manager.addColony(i, plantUnlocks[j], amount);
+                if (actuallyPlanting) {
+                    // Check notebook for max level
+                    if (theory.isBuyAllAvailable && notebook[plantUnlocks[j]] &&
+                        plants[i][plantUnlocks[j]].level >
+                            notebook[plantUnlocks[j]].maxLevel)
+                        plants[i][plantUnlocks[j]].refund(amount);
+                    else
+                        manager.addColony(i, plantUnlocks[j], amount);
+                }
             };
             plants[i][plantUnlocks[j]].isAvailable = false;
         }
@@ -3666,6 +3677,8 @@ var init = () => {
     theory.createPublicationUpgrade(1, currency, permaCosts[0]);
     theory.publicationUpgrade.bought = (_) => theory.invalidateQuaternaryValues();
     theory.createBuyAllUpgrade(2, currency, permaCosts[1]);
+    theory.buyAllUpgrade.description = getLoc('permaNote');
+    theory.buyAllUpgrade.info = getLoc('permaNoteInfo');
     // theory.createAutoBuyerUpgrade(3, currency, permaCosts[2]);
     /* Pause
     For testing purposes
@@ -3700,9 +3713,9 @@ var init = () => {
     */
     {
         warpTick = theory.createPermanentUpgrade(9004, currency, new FreeCost);
-        warpTick.description = 'Warp 1.5 minutes';
-        warpTick.info = 'Warps forward by 0.15 time units';
-        warpTick.bought = (_) => tick(0.15, 1);
+        warpTick.description = 'Warp tick';
+        warpTick.info = 'Warps forward by a tick';
+        warpTick.bought = (_) => tick(0.1, 1);
         warpTick.isAvailable = haxEnabled;
     }
     /* Warp one
@@ -3710,9 +3723,9 @@ var init = () => {
     */
     {
         warpDay = theory.createPermanentUpgrade(9003, currency, new FreeCost);
-        warpDay.description = 'Warp one day';
+        warpDay.description = 'Warp day';
         warpDay.info = 'Warps forward by a day';
-        warpDay.bought = (_) => tick(dayLength, 1);
+        warpDay.bought = (_) => tick(dayLength / speeds[speedIdx], 1);
         warpDay.isAvailable = haxEnabled;
     }
     /* Warp year
@@ -3720,9 +3733,9 @@ var init = () => {
     */
     {
         warpYear = theory.createPermanentUpgrade(9005, currency, new FreeCost);
-        warpYear.description = 'Warp one year';
+        warpYear.description = 'Warp year';
         warpYear.info = 'Warps forward by 365 days';
-        warpYear.bought = (_) => tick(dayLength * 365, 1);
+        warpYear.bought = (_) => tick(dayLength * 365 / speeds[speedIdx], 1);
         warpYear.isAvailable = haxEnabled;
     }
     /* Warp zero
@@ -4678,19 +4691,9 @@ let createNotebookMenu = () => {
             horizontalTextAlignment: TextAlignment.END,
             onTextChanged: (ot, nt) => {
                 let tmpML = Number(nt) ?? INT_MAX;
-                for (let j = 0; j < nofPlots; ++j) {
-                    let count = 0;
-                    for (let k = 0; k < manager.colonies[j].length; ++k) {
-                        let c = manager.colonies[j][k];
-                        if (c.id == plantUnlocks[i] && !c.propagated) {
-                            count += c.population;
-                            tmpML = Math.max(tmpML, count);
-                        }
-                    }
-                }
                 notebook[plantUnlocks[i]].maxLevel = tmpML;
-                for (let j = 0; j < nofPlots; ++j)
-                    plants[j][plantUnlocks[i]].maxLevel = tmpML;
+                // for(let j = 0; j < nofPlots; ++j)
+                //     plants[j][plantUnlocks[i]].maxLevel = tmpML;
             }
         });
         let tmpMinusBtn = ui.createButton({
@@ -4736,7 +4739,7 @@ let createNotebookMenu = () => {
     });
     let menu = ui.createPopup({
         isPeekable: true,
-        title: getLoc('permaNote'),
+        title: getLoc('menuNote'),
         content: ui.createStackLayout({
             children: [
                 ui.createGrid({
@@ -4811,7 +4814,7 @@ let createShelfMenu = () => {
                 }),
                 ui.createButton({
                     isVisible: theory.isBuyAllAvailable,
-                    text: getLoc('permaNote'),
+                    text: getLoc('menuNote'),
                     onClicked: () => {
                         Sound.playClick();
                         let menu = createNotebookMenu();
@@ -5315,9 +5318,12 @@ var setInternalState = (stateStr) => {
         }
         for (let j = 0; j < plantUnlocks.length; ++j) {
             plants[i][plantUnlocks[j]].level = tmpLevels[i][plantUnlocks[j]];
-            if (theory.isBuyAllAvailable && notebook[plantUnlocks[j]]) {
-                plants[i][plantUnlocks[j]].maxLevel = Math.max(notebook[plantUnlocks[j]].maxLevel, plants[i][plantUnlocks[j]].level);
-            }
+            // if(theory.isBuyAllAvailable && notebook[plantUnlocks[j]])
+            // {
+            //     plants[i][plantUnlocks[j]].maxLevel = Math.max(
+            //     notebook[plantUnlocks[j]].maxLevel,
+            //     plants[i][plantUnlocks[j]].level);
+            // }
         }
     }
     actuallyPlanting = true;


### PR DESCRIPTION
**Balance changes:**
- Fixed float precision error on calendula leaves (slight nerf)
- Calendula spread rate: 40% → 1/3
- Basil unlock: 2200p → 2100p
- Rose campion max stage: 28 → 29
- Rose campion fruit minimum size: 0.6 → 0.5
- Rose campion fruit now falls off when reaching minimum size
- Rose campion spread stage: 20 → 27 (aligning with fruit falling off)
- Rose campion spread rate: 60% → 1/2
- Notebook unlock: 4800p → 3600p

**QoL changes:**
- Notebook no longer imposes a max level by the game engine, allowing players to see the next cost
- Notebook now properly supports changing level cap to infinite (by pressing minus when at 0)

**Fixes:**
- Time warping in hax mode is no longer affected by the speed setting